### PR TITLE
Configure Neovim terminals to use PowerShell

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -31,11 +31,16 @@ vim.opt.mouse = 'a'
 if vim.fn.has 'win32' == 1 then
   local powershell_exe = vim.fn.exepath 'pwsh.exe'
   if powershell_exe ~= '' then
+    vim.opt.shell = powershell_exe
+    vim.opt.shellcmdflag =
+      '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;'
+    vim.opt.shellredir = '2>&1 | Out-File -Encoding UTF8 %s'
+    vim.opt.shellpipe = '2>&1 | Out-File -Encoding UTF8 %s'
+    vim.opt.shellquote = ''
+    vim.opt.shellxquote = ''
+
     local quoted_pwsh = string.format([[%q]], powershell_exe)
-
-    vim.g.custom_pwsh_terminal_cmd = quoted_pwsh
-
-    vim.opt.shell = quoted_pwsh
+    vim.g.custom_pwsh_terminal_cmd = string.format('%s -NoLogo', quoted_pwsh)
 
     -- Keep the PowerShell profile OSC-7 snippet in sync with this setup so directory-aware
     -- tools continue to work the same in both WezTerm and Neovim terminals.

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -28,6 +28,28 @@ vim.opt.relativenumber = true
 -- Enable mouse mode, can be useful for resizing splits for example!
 vim.opt.mouse = 'a'
 
+if vim.fn.has 'win32' == 1 then
+  local powershell_exe = vim.fn.exepath 'pwsh.exe'
+  if powershell_exe ~= '' then
+    local quoted_pwsh = string.format([[%q]], powershell_exe)
+    local pwsh_startup_flags = '-NoLogo -NoProfile'
+    local pwsh_terminal = string.format('%s %s', quoted_pwsh, pwsh_startup_flags)
+
+    vim.g.custom_pwsh_terminal_cmd = pwsh_terminal
+
+    vim.opt.shell = pwsh_terminal
+    vim.opt.shellcmdflag =
+      ' -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;'
+    vim.opt.shellquote = ''
+    vim.opt.shellxquote = ''
+    vim.opt.shellpipe = '2>&1 | Out-File -Encoding UTF8 %s'
+    vim.opt.shellredir = '2>&1 | Out-File -Encoding UTF8 %s'
+
+    -- Keep the PowerShell profile OSC-7 snippet in sync with this setup so directory-aware
+    -- tools continue to work the same in both WezTerm and Neovim terminals.
+  end
+end
+
 -- Don't show the mode, since it's already in the status line
 vim.opt.showmode = false
 

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -32,18 +32,10 @@ if vim.fn.has 'win32' == 1 then
   local powershell_exe = vim.fn.exepath 'pwsh.exe'
   if powershell_exe ~= '' then
     local quoted_pwsh = string.format([[%q]], powershell_exe)
-    local pwsh_startup_flags = '-NoLogo -NoProfile'
-    local pwsh_terminal = string.format('%s %s', quoted_pwsh, pwsh_startup_flags)
 
-    vim.g.custom_pwsh_terminal_cmd = pwsh_terminal
+    vim.g.custom_pwsh_terminal_cmd = quoted_pwsh
 
-    vim.opt.shell = pwsh_terminal
-    vim.opt.shellcmdflag =
-      ' -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;'
-    vim.opt.shellquote = ''
-    vim.opt.shellxquote = ''
-    vim.opt.shellpipe = '2>&1 | Out-File -Encoding UTF8 %s'
-    vim.opt.shellredir = '2>&1 | Out-File -Encoding UTF8 %s'
+    vim.opt.shell = quoted_pwsh
 
     -- Keep the PowerShell profile OSC-7 snippet in sync with this setup so directory-aware
     -- tools continue to work the same in both WezTerm and Neovim terminals.

--- a/nvim/lua/custom/plugins/toggleterm.lua
+++ b/nvim/lua/custom/plugins/toggleterm.lua
@@ -10,7 +10,7 @@ return {{
             if not shell or shell == '' then
                 local powershell_exe = vim.fn.exepath 'pwsh.exe'
                 if powershell_exe ~= '' then
-                    shell = string.format([[%q -NoLogo -NoProfile]], powershell_exe)
+                    shell = string.format([[%q]], powershell_exe)
                 end
             end
 

--- a/nvim/lua/custom/plugins/toggleterm.lua
+++ b/nvim/lua/custom/plugins/toggleterm.lua
@@ -10,7 +10,7 @@ return {{
             if not shell or shell == '' then
                 local powershell_exe = vim.fn.exepath 'pwsh.exe'
                 if powershell_exe ~= '' then
-                    shell = string.format([[%q]], powershell_exe)
+                    shell = string.format('%s -NoLogo', string.format([[%q]], powershell_exe))
                 end
             end
 

--- a/nvim/lua/custom/plugins/toggleterm.lua
+++ b/nvim/lua/custom/plugins/toggleterm.lua
@@ -1,5 +1,24 @@
 return {{
     'akinsho/toggleterm.nvim',
     version = '*',
-    config = true
+    opts = function()
+        local options = {}
+
+        if vim.fn.has 'win32' == 1 then
+            local shell = vim.g.custom_pwsh_terminal_cmd
+
+            if not shell or shell == '' then
+                local powershell_exe = vim.fn.exepath 'pwsh.exe'
+                if powershell_exe ~= '' then
+                    shell = string.format([[%q -NoLogo -NoProfile]], powershell_exe)
+                end
+            end
+
+            if shell and shell ~= '' then
+                options.shell = shell
+            end
+        end
+
+        return options
+    end,
 }}


### PR DESCRIPTION
## Summary
- configure Neovim's shell options on Windows to launch PowerShell 7 with no profile/logo and UTF-8 redirection, and note the OSC-7 profile requirement
- reuse the same PowerShell command for toggleterm terminals with a quoted fallback lookup

## Testing
- not run
 