### PR TITLE
feat(nvim): add rust code helper mappings

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -10,6 +10,18 @@ A starting point for Neovim that is:
 
 **NOT** a Neovim distribution, but instead a starting point for your configuration.
 
+## Custom Keymaps
+
+### Rust tools
+
+| Shortcut | Action |
+| --- | --- |
+| `<leader>crd` | Generate a docstring for the Rust item under the cursor with `:RustDocstring`. |
+| `<leader>crD` | Insert docstrings for every supported Rust item in the current buffer via `:RustDocstringAllKinds`. |
+| `<leader>crr` | Open the `RustLsp runnables` picker. |
+| `<leader>crp` | Jump to the parent module using `RustLsp parentModule`. |
+| `<leader>crm` | Expand the macro call at the cursor through `RustLsp expandMacro`. |
+
 ## Installation
 
 ### Install Neovim

--- a/nvim/lua/custom/plugins/extra_keybinds.lua
+++ b/nvim/lua/custom/plugins/extra_keybinds.lua
@@ -23,6 +23,23 @@ return (function()
   vim.keymap.set('n', '<leader>ccu', '<cmd>tabnew | term cargo update<cr>', { desc = '[C]ode [C]argo [U]pdate deps' })
   vim.keymap.set('n', '<leader>ccf', '<cmd>tabnew | term cargo fmt<cr>', { desc = '[C]ode [C]argo [F]ormat code' })
   vim.keymap.set('n', '<leader>ccl', '<cmd>tabnew | term cargo clippy<cr>', { desc = '[C]ode [C]argo C[L]ippy lint' })
+  -- Rust tooling under <leader>cr
+  vim.keymap.set('n', '<leader>cr', '<Nop>', { desc = '[C]ode [R]ust' })
+  vim.keymap.set('n', '<leader>crd', function()
+    vim.cmd.RustDocstring()
+  end, { desc = '[C]ode [R]ust [D]ocstring current item' })
+  vim.keymap.set('n', '<leader>crD', function()
+    vim.cmd.RustDocstringAllKinds()
+  end, { desc = '[C]ode [R]ust [D]ocstring all kinds' })
+  vim.keymap.set('n', '<leader>crr', function()
+    vim.cmd.RustLsp { 'runnables' }
+  end, { desc = '[C]ode [R]ust [R]unnables' })
+  vim.keymap.set('n', '<leader>crp', function()
+    vim.cmd.RustLsp { 'parentModule' }
+  end, { desc = '[C]ode [R]ust [P]arent module' })
+  vim.keymap.set('n', '<leader>crm', function()
+    vim.cmd.RustLsp { 'expandMacro' }
+  end, { desc = '[C]ode [R]ust expand [M]acro' })
   -- Increase font size
   vim.keymap.set('n', '<C-=>', function()
     local font = vim.o.guifont

--- a/nvim/lua/custom/plugins/whichkey.lua
+++ b/nvim/lua/custom/plugins/whichkey.lua
@@ -59,6 +59,11 @@ return {
           mode = { 'n', 'x' },
         },
         {
+          '<leader>cr',
+          group = '[c]ode [r]ust',
+          mode = { 'n' },
+        },
+        {
           '<leader>d',
           group = '[d]ocument and dashboard',
         },


### PR DESCRIPTION
## Summary
- add <leader>cr mappings for generating Rust docstrings and invoking rust-analyzer helpers
- register the new Rust code subgroup with which-key
- document the Rust shortcuts in the Neovim README

## Testing
- not run (neovim CLI not available in container)
 