### PR TITLE
Handle optional cmp capabilities for Koto LSP

### DIFF
--- a/nvim/lua/custom/plugins/koto.lua
+++ b/nvim/lua/custom/plugins/koto.lua
@@ -36,6 +36,13 @@ return {
       -- Use lspconfig.util just for root detection (safe submodule)
       local util = require 'lspconfig.util'
 
+      -- Prepare LSP capabilities (optionally enhanced by nvim-cmp)
+      local capabilities = vim.lsp.protocol.make_client_capabilities()
+      local ok_cmp, cmp = pcall(require, 'cmp_nvim_lsp')
+      if ok_cmp and cmp then
+        capabilities = cmp.default_capabilities(capabilities)
+      end
+
       -- Start koto-ls on Koto buffers
       vim.api.nvim_create_autocmd('FileType', {
         pattern = 'koto',
@@ -51,6 +58,7 @@ return {
             name = 'koto-ls',
             cmd = { 'koto-ls' }, -- ensure it's on PATH (cargo install koto-ls)
             root_dir = root,
+            capabilities = capabilities,
           }, { bufnr = args.buf })
         end,
       })


### PR DESCRIPTION
## Summary
- prepare a reusable LSP capabilities table for the Koto autocmd and augment it with cmp defaults when available
- reuse the cached capabilities when starting koto-ls to avoid repeated module loading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddc3760fc0833288906e69a0c962d4