### PR TITLE
feat: enable koto-ls completion for nvim-cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ MyDotFiles
 
 * Wezterm
 * Neovim
+  * `koto-ls` must be available on your `$PATH` (e.g. `cargo install koto-ls`) for Koto LSP features.

--- a/nvim/lua/custom/plugins/koto.lua
+++ b/nvim/lua/custom/plugins/koto.lua
@@ -36,6 +36,16 @@ return {
       -- Use lspconfig.util just for root detection (safe submodule)
       local util = require 'lspconfig.util'
 
+      local merged_capabilities = vim.lsp.protocol.make_client_capabilities()
+      local ok, cmp_nvim_lsp = pcall(require, 'cmp_nvim_lsp')
+      if ok and cmp_nvim_lsp then
+        merged_capabilities = vim.tbl_deep_extend(
+          'force',
+          merged_capabilities,
+          cmp_nvim_lsp.default_capabilities()
+        )
+      end
+
       -- Start koto-ls on Koto buffers
       vim.api.nvim_create_autocmd('FileType', {
         pattern = 'koto',
@@ -51,6 +61,7 @@ return {
             name = 'koto-ls',
             cmd = { 'koto-ls' }, -- ensure it's on PATH (cargo install koto-ls)
             root_dir = root,
+            capabilities = merged_capabilities,
           }, { bufnr = args.buf })
         end,
       })


### PR DESCRIPTION
## Summary
- merge cmp-nvim-lsp default capabilities with the koto-ls client so completion is advertised
- document that koto-ls must be on the PATH for the language server integration

## Testing
- not run (Neovim not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddc38511f88332b1fec224a449b442