### PR TITLE
feat: enhance Koto LSP startup

### DIFF
--- a/nvim/lua/custom/plugins/koto.lua
+++ b/nvim/lua/custom/plugins/koto.lua
@@ -44,6 +44,17 @@ return {
           if vim.lsp.get_clients({ bufnr = args.buf, name = 'koto-ls' })[1] then
             return
           end
+
+          if vim.fn.executable('koto-ls') == 0 then
+            vim.notify('koto-ls not found on PATH. Install via `cargo install koto-ls` for language server support.', vim.log.levels.WARN)
+            return
+          end
+
+          local capabilities = vim.lsp.protocol.make_client_capabilities()
+          local ok_cmp, cmp_nvim_lsp = pcall(require, 'cmp_nvim_lsp')
+          if ok_cmp and cmp_nvim_lsp and cmp_nvim_lsp.default_capabilities then
+            capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
+          end
           local fname = vim.api.nvim_buf_get_name(args.buf)
           local root = util.root_pattern '.git'(fname) or util.path.dirname(fname)
 
@@ -51,6 +62,7 @@ return {
             name = 'koto-ls',
             cmd = { 'koto-ls' }, -- ensure it's on PATH (cargo install koto-ls)
             root_dir = root,
+            capabilities = capabilities,
           }, { bufnr = args.buf })
         end,
       })


### PR DESCRIPTION
## Summary
- ensure the Koto FileType autocmd warns when `koto-ls` is missing and builds cmp-aware LSP capabilities
- pass the merged capabilities into `vim.lsp.start` so the language server advertises completion support

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ddc37fcea48332aa159b71633581fc