### PR TITLE
Add Rhai tooling to Neovim config

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -172,6 +172,10 @@ vim.filetype.add {
   extension = { koto = 'koto' },
 }
 
+vim.filetype.add {
+  extension = { rhai = 'rhai' },
+}
+
 require('lazy').setup({ {
   import = 'custom.plugins',
 } }, {

--- a/nvim/lua/custom/lang/rhai.lua
+++ b/nvim/lua/custom/lang/rhai.lua
@@ -1,0 +1,138 @@
+local M = {}
+
+local function get_lsp_util()
+  local ok, util = pcall(require, 'lspconfig.util')
+  if ok then
+    return util
+  end
+  local ok_alt, lspconfig = pcall(require, 'lspconfig')
+  if ok_alt and lspconfig.util then
+    return lspconfig.util
+  end
+  return nil
+end
+
+function M.get_root(fname)
+  if not fname or fname == '' then
+    return vim.fn.getcwd()
+  end
+
+  local util = get_lsp_util()
+  if util then
+    local root = util.root_pattern('Rhai.toml', '.git')(fname)
+    if root and root ~= '' then
+      return root
+    end
+    local parent = util.path and util.path.dirname and util.path.dirname(fname)
+    if parent and parent ~= '' then
+      return parent
+    end
+  end
+
+  local dir = vim.fs.dirname(fname)
+  if dir and dir ~= '' then
+    local found = vim.fs.find({ 'Rhai.toml', '.git' }, { upward = true, path = dir })[1]
+    if found then
+      return vim.fs.dirname(found)
+    end
+    return dir
+  end
+
+  return vim.fn.getcwd()
+end
+
+function M.rhai_executable(opts)
+  if vim.fn.executable 'rhai' == 1 then
+    return true
+  end
+  if not (opts and opts.silent) then
+    vim.notify('`rhai` executable not found in PATH', vim.log.levels.WARN)
+  end
+  return false
+end
+
+function M.has_formatter(bufnr)
+  for _, client in ipairs(vim.lsp.get_clients { bufnr = bufnr }) do
+    if client.supports_method and client:supports_method 'textDocument/formatting' then
+      return true
+    end
+  end
+  return false
+end
+
+function M.ensure_rhai_file(bufnr)
+  local file = vim.api.nvim_buf_get_name(bufnr or 0)
+  if file == '' or not file:match '%.rhai$' then
+    vim.notify('Not a .rhai buffer', vim.log.levels.WARN)
+    return nil
+  end
+  return file
+end
+
+function M.cli_fmt(file, root, opts)
+  if not M.rhai_executable(opts) then
+    return false
+  end
+  local result = vim.system({ 'rhai', 'fmt', file }, { cwd = root, text = true }):wait()
+  if result.code ~= 0 then
+    local err = result.stderr
+    if err == '' then
+      err = result.stdout
+    end
+    vim.notify('rhai fmt failed: ' .. (err ~= '' and err or 'unknown error'), vim.log.levels.ERROR)
+    return false
+  end
+  return true
+end
+
+function M.format_buffer(bufnr)
+  if M.has_formatter(bufnr) then
+    vim.lsp.buf.format { bufnr = bufnr, async = false }
+    return true
+  end
+
+  local file = M.ensure_rhai_file(bufnr)
+  if not file then
+    return false
+  end
+
+  local root = M.get_root(file)
+  local ok = M.cli_fmt(file, root)
+  if ok then
+    vim.api.nvim_buf_call(bufnr, function()
+      vim.cmd('silent! keepalt keepjumps noautocmd edit!')
+    end)
+  end
+  return ok
+end
+
+function M.run_overseer(cmd, args, cwd)
+  local ok, overseer = pcall(require, 'overseer')
+  if not ok then
+    return false
+  end
+  local task = overseer.new_task {
+    cmd = cmd,
+    args = args or {},
+    cwd = cwd or vim.fn.getcwd(),
+    components = { 'default' },
+  }
+  task:start()
+  overseer.open { enter = false, direction = 'bottom' }
+  return true
+end
+
+function M.term_run(cmd, args, cwd)
+  cwd = cwd or vim.fn.getcwd()
+  vim.cmd 'botright 12split'
+  local win = vim.api.nvim_get_current_win()
+  local command = { cmd }
+  if args and #args > 0 then
+    command = vim.list_extend(command, vim.deepcopy(args))
+  end
+  vim.fn.termopen(command, { cwd = cwd })
+  vim.api.nvim_set_current_win(win)
+  vim.cmd 'startinsert'
+end
+
+return M

--- a/nvim/lua/custom/plugins/extra_keybinds.lua
+++ b/nvim/lua/custom/plugins/extra_keybinds.lua
@@ -1,4 +1,6 @@
 return (function()
+  local rhai_utils = require 'custom.lang.rhai'
+
   -- NIM
   vim.keymap.set('n', '<leader>npr', function()
     local dir_path = vim.fn.expand '%:p:h'
@@ -16,6 +18,46 @@ return (function()
   vim.keymap.set('n', '<leader>ccd', '<cmd>tabnew | term cargo doc --open<cr>', { desc = '[C]ode [C]argo [D]oc open' })
   vim.keymap.set('n', '<leader>ccu', '<cmd>tabnew | term cargo update<cr>', { desc = '[C]ode [C]argo [U]pdate deps' })
   vim.keymap.set('n', '<leader>ccf', '<cmd>tabnew | term cargo fmt<cr>', { desc = '[C]ode [C]argo [F]ormat code' })
+  vim.api.nvim_create_autocmd('FileType', {
+    pattern = 'rhai',
+    callback = function(ev)
+      local buf = ev.buf
+
+      vim.keymap.set('n', '<leader>cRf', function()
+        rhai_utils.format_buffer(buf)
+      end, { buffer = buf, desc = '[C]ode [R]hai [F]ormat buffer' })
+
+      vim.keymap.set('n', '<leader>cRF', function()
+        if not rhai_utils.rhai_executable() then
+          return
+        end
+        local args = { 'fmt' }
+        local root = rhai_utils.get_root(vim.api.nvim_buf_get_name(buf))
+        if not rhai_utils.run_overseer('rhai', args, root) then
+          rhai_utils.term_run('rhai', args, root)
+        end
+      end, { buffer = buf, desc = '[C]ode [R]hai [F]ormat workspace' })
+
+      vim.keymap.set('n', '<leader>cRc', function()
+        if not rhai_utils.rhai_executable() then
+          return
+        end
+        local args = { 'fmt', '--check' }
+        local root = rhai_utils.get_root(vim.api.nvim_buf_get_name(buf))
+        if not rhai_utils.run_overseer('rhai', args, root) then
+          rhai_utils.term_run('rhai', args, root)
+        end
+      end, { buffer = buf, desc = '[C]ode [R]hai [C]heck formatting' })
+
+      vim.keymap.set('n', '<leader>cRh', vim.lsp.buf.hover, { buffer = buf, desc = '[C]ode [R]hai [H]over' })
+      vim.keymap.set('n', '<leader>cRg', vim.lsp.buf.definition, { buffer = buf, desc = '[C]ode [R]hai [G]oto def' })
+      vim.keymap.set('n', '<leader>cRn', vim.lsp.buf.rename, { buffer = buf, desc = '[C]ode [R]hai Re[n]ame' })
+      vim.keymap.set({ 'n', 'x' }, '<leader>cRa', vim.lsp.buf.code_action, {
+        buffer = buf,
+        desc = '[C]ode [R]hai Code [A]ction',
+      })
+    end,
+  })
   -- Rust execution, testing, and linting under <leader>cr
   vim.keymap.set('n', '<leader>cr', '<Nop>', { desc = '[C]ode [R]ust' })
   vim.keymap.set('n', '<leader>crr', '<cmd>tabnew | term cargo run<cr>', { desc = '[C]ode [R]ust [R]un' })

--- a/nvim/lua/custom/plugins/rhai.lua
+++ b/nvim/lua/custom/plugins/rhai.lua
@@ -1,0 +1,233 @@
+-- lua/custom/plugins/rhai.lua
+return {
+  { 'kuon/rhai.vim' },
+  -------------------------------------------------------------------------
+  -- 1) Treesitter: register external Rhai parser + ensure it's installed
+  -------------------------------------------------------------------------
+  {
+    'nvim-treesitter/nvim-treesitter',
+    opts = function(_, opts)
+      local parser_config = require('nvim-treesitter.parsers').get_parser_configs()
+      parser_config.rhai = parser_config.rhai
+        or {
+          install_info = {
+            url = 'https://github.com/elkowar/tree-sitter-rhai',
+            files = { 'src/parser.c' },
+          },
+          filetype = 'rhai',
+        }
+
+      opts.ensure_installed = opts.ensure_installed or {}
+      if not vim.tbl_contains(opts.ensure_installed, 'rhai') then
+        table.insert(opts.ensure_installed, 'rhai')
+      end
+    end,
+  },
+
+  -------------------------------------------------------------------------
+  -- 2) LSP + tooling integration for Rhai
+  -------------------------------------------------------------------------
+  {
+    'neovim/nvim-lspconfig',
+    lazy = false,
+    init = function()
+      vim.filetype.add { extension = { rhai = 'rhai' } }
+
+      local lspconfig = require 'lspconfig'
+      local util = lspconfig.util
+
+      local function get_root(fname)
+        if fname and fname ~= '' then
+          return util.root_pattern('Rhai.toml', '.git')(fname) or util.path.dirname(fname)
+        end
+        return vim.fn.getcwd()
+      end
+
+      local function has_formatter(bufnr)
+        for _, client in ipairs(vim.lsp.get_clients { bufnr = bufnr }) do
+          if client.supports_method and client:supports_method 'textDocument/formatting' then
+            return true
+          end
+        end
+        return false
+      end
+
+      local function rhai_executable(opts)
+        if vim.fn.executable 'rhai' == 1 then
+          return true
+        end
+        if not (opts and opts.silent) then
+          vim.notify('`rhai` executable not found in PATH', vim.log.levels.WARN)
+        end
+        return false
+      end
+
+      local function cli_fmt(file, root, opts)
+        if not rhai_executable(opts) then
+          return false
+        end
+        local result = vim.system({ 'rhai', 'fmt', file }, { cwd = root, text = true }):wait()
+        if result.code ~= 0 then
+          local err = result.stderr
+          if err == '' then
+            err = result.stdout
+          end
+          vim.notify('rhai fmt failed: ' .. (err ~= '' and err or 'unknown error'), vim.log.levels.ERROR)
+          return false
+        end
+        return true
+      end
+
+      vim.api.nvim_create_autocmd('FileType', {
+        pattern = 'rhai',
+        callback = function(args)
+          local buf = args.buf
+          local fname = vim.api.nvim_buf_get_name(buf)
+          local root = get_root(fname)
+
+          if vim.lsp.get_clients { bufnr = buf, name = 'rhai-lsp' }[1] then
+            return
+          end
+
+          for _, client in ipairs(vim.lsp.get_clients { name = 'rhai-lsp' }) do
+            if client.config and client.config.root_dir == root then
+              vim.lsp.buf_attach_client(buf, client.id)
+              return
+            end
+          end
+
+          if not rhai_executable() then
+            return
+          end
+
+          vim.lsp.start({
+            name = 'rhai-lsp',
+            cmd = { 'rhai', 'lsp', 'stdio' },
+            root_dir = root,
+          }, { bufnr = buf })
+        end,
+      })
+
+      vim.api.nvim_create_autocmd('BufWritePre', {
+        pattern = '*.rhai',
+        callback = function(ev)
+          local buf = ev.buf
+          if has_formatter(buf) then
+            vim.lsp.buf.format { bufnr = buf, async = false }
+            return
+          end
+
+          local file = vim.api.nvim_buf_get_name(buf)
+          if file == '' then
+            return
+          end
+
+          local root = get_root(file)
+          if cli_fmt(file, root) then
+            vim.api.nvim_buf_call(buf, function()
+              vim.cmd('silent! keepalt keepjumps noautocmd edit!')
+            end)
+          end
+        end,
+      })
+
+      pcall(require('which-key').add, {
+        { '<leader>cR', group = '[C]ode [R]hai' },
+      })
+
+      vim.api.nvim_create_autocmd('FileType', {
+        pattern = 'rhai',
+        callback = function(ev)
+          local buf = ev.buf
+          local fname = vim.api.nvim_buf_get_name(buf)
+          local root = get_root(fname)
+
+          local function ensure_rhai_file()
+            local file = vim.api.nvim_buf_get_name(buf)
+            if file == '' or not file:match '%.rhai$' then
+              vim.notify('Not a .rhai buffer', vim.log.levels.WARN)
+              return nil
+            end
+            return file
+          end
+
+          local function run_overseer(cmd, args, cwd)
+            local ok, overseer = pcall(require, 'overseer')
+            if not ok then
+              return false
+            end
+            local task = overseer.new_task {
+              cmd = cmd,
+              args = args or {},
+              cwd = cwd or root,
+              components = { 'default' },
+            }
+            task:start()
+            overseer.open { enter = false, direction = 'bottom' }
+            return true
+          end
+
+          local function term_run(cmd, args, cwd)
+            cwd = cwd or root
+            vim.cmd 'botright 12split'
+            local win = vim.api.nvim_get_current_win()
+            local command = vim.list_extend({ cmd }, args or {})
+            vim.fn.termopen(command, { cwd = cwd })
+            vim.api.nvim_set_current_win(win)
+            vim.cmd 'startinsert'
+          end
+
+          local function format_current_buffer()
+            if has_formatter(buf) then
+              vim.lsp.buf.format { bufnr = buf, async = false }
+              return true
+            end
+            local file = ensure_rhai_file()
+            if not file then
+              return false
+            end
+            local ok = cli_fmt(file, root)
+            if ok then
+              vim.api.nvim_buf_call(buf, function()
+                vim.cmd('silent! keepalt keepjumps noautocmd edit!')
+              end)
+            end
+            return ok
+          end
+
+          vim.keymap.set('n', '<leader>cRf', function()
+            format_current_buffer()
+          end, { buffer = buf, desc = '[C]ode [R]hai [F]ormat buffer' })
+
+          vim.keymap.set('n', '<leader>cRF', function()
+            if not rhai_executable() then
+              return
+            end
+            local args = { 'fmt' }
+            if not run_overseer('rhai', args, root) then
+              term_run('rhai', args, root)
+            end
+          end, { buffer = buf, desc = '[C]ode [R]hai [F]ormat workspace' })
+
+          vim.keymap.set('n', '<leader>cRc', function()
+            if not rhai_executable() then
+              return
+            end
+            local args = { 'fmt', '--check' }
+            if not run_overseer('rhai', args, root) then
+              term_run('rhai', args, root)
+            end
+          end, { buffer = buf, desc = '[C]ode [R]hai [C]heck formatting' })
+
+          vim.keymap.set('n', '<leader>cRh', vim.lsp.buf.hover, { buffer = buf, desc = '[C]ode [R]hai [H]over' })
+          vim.keymap.set('n', '<leader>cRg', vim.lsp.buf.definition, { buffer = buf, desc = '[C]ode [R]hai [G]oto def' })
+          vim.keymap.set('n', '<leader>cRn', vim.lsp.buf.rename, { buffer = buf, desc = '[C]ode [R]hai Re[n]ame' })
+          vim.keymap.set({ 'n', 'x' }, '<leader>cRa', vim.lsp.buf.code_action, {
+            buffer = buf,
+            desc = '[C]ode [R]hai Code [A]ction',
+          })
+        end,
+      })
+    end,
+  },
+}

--- a/nvim/lua/custom/plugins/rhai.lua
+++ b/nvim/lua/custom/plugins/rhai.lua
@@ -43,6 +43,25 @@ return {
         return vim.fn.getcwd()
       end
 
+      local notified_roots = {}
+
+      local function notify_status(success, root, err)
+        root = root or vim.fn.getcwd()
+        if success then
+          if notified_roots[root] then
+            return
+          end
+          notified_roots[root] = true
+          vim.notify(('Rhai tooling ready (%s)'):format(root), vim.log.levels.INFO)
+          return
+        end
+        local msg = 'Failed to start Rhai tooling'
+        if err and err ~= '' then
+          msg = ('%s: %s'):format(msg, err)
+        end
+        vim.notify(msg, vim.log.levels.ERROR)
+      end
+
       local function has_formatter(bufnr)
         for _, client in ipairs(vim.lsp.get_clients { bufnr = bufnr }) do
           if client.supports_method and client:supports_method 'textDocument/formatting' then
@@ -86,12 +105,14 @@ return {
           local root = get_root(fname)
 
           if vim.lsp.get_clients { bufnr = buf, name = 'rhai-lsp' }[1] then
+            notify_status(true, root)
             return
           end
 
           for _, client in ipairs(vim.lsp.get_clients { name = 'rhai-lsp' }) do
             if client.config and client.config.root_dir == root then
               vim.lsp.buf_attach_client(buf, client.id)
+              notify_status(true, root)
               return
             end
           end
@@ -100,11 +121,22 @@ return {
             return
           end
 
-          vim.lsp.start({
+          local ok, result = pcall(vim.lsp.start, {
             name = 'rhai-lsp',
             cmd = { 'rhai', 'lsp', 'stdio' },
             root_dir = root,
           }, { bufnr = buf })
+
+          if not ok then
+            notify_status(false, root, result)
+            return
+          end
+
+          if result then
+            notify_status(true, root)
+          else
+            notify_status(false, root)
+          end
         end,
       })
 

--- a/nvim/lua/custom/plugins/rhai.lua
+++ b/nvim/lua/custom/plugins/rhai.lua
@@ -33,15 +33,8 @@ return {
     init = function()
       vim.filetype.add { extension = { rhai = 'rhai' } }
 
-      local lspconfig = require 'lspconfig'
-      local util = lspconfig.util
-
-      local function get_root(fname)
-        if fname and fname ~= '' then
-          return util.root_pattern('Rhai.toml', '.git')(fname) or util.path.dirname(fname)
-        end
-        return vim.fn.getcwd()
-      end
+      require 'lspconfig'
+      local rhai_utils = require 'custom.lang.rhai'
 
       local notified_roots = {}
 
@@ -62,47 +55,12 @@ return {
         vim.notify(msg, vim.log.levels.ERROR)
       end
 
-      local function has_formatter(bufnr)
-        for _, client in ipairs(vim.lsp.get_clients { bufnr = bufnr }) do
-          if client.supports_method and client:supports_method 'textDocument/formatting' then
-            return true
-          end
-        end
-        return false
-      end
-
-      local function rhai_executable(opts)
-        if vim.fn.executable 'rhai' == 1 then
-          return true
-        end
-        if not (opts and opts.silent) then
-          vim.notify('`rhai` executable not found in PATH', vim.log.levels.WARN)
-        end
-        return false
-      end
-
-      local function cli_fmt(file, root, opts)
-        if not rhai_executable(opts) then
-          return false
-        end
-        local result = vim.system({ 'rhai', 'fmt', file }, { cwd = root, text = true }):wait()
-        if result.code ~= 0 then
-          local err = result.stderr
-          if err == '' then
-            err = result.stdout
-          end
-          vim.notify('rhai fmt failed: ' .. (err ~= '' and err or 'unknown error'), vim.log.levels.ERROR)
-          return false
-        end
-        return true
-      end
-
       vim.api.nvim_create_autocmd('FileType', {
         pattern = 'rhai',
         callback = function(args)
           local buf = args.buf
           local fname = vim.api.nvim_buf_get_name(buf)
-          local root = get_root(fname)
+          local root = rhai_utils.get_root(fname)
 
           if vim.lsp.get_clients { bufnr = buf, name = 'rhai-lsp' }[1] then
             notify_status(true, root)
@@ -117,7 +75,7 @@ return {
             end
           end
 
-          if not rhai_executable() then
+          if not rhai_utils.rhai_executable() then
             return
           end
 
@@ -144,121 +102,12 @@ return {
         pattern = '*.rhai',
         callback = function(ev)
           local buf = ev.buf
-          if has_formatter(buf) then
-            vim.lsp.buf.format { bufnr = buf, async = false }
-            return
-          end
-
-          local file = vim.api.nvim_buf_get_name(buf)
-          if file == '' then
-            return
-          end
-
-          local root = get_root(file)
-          if cli_fmt(file, root) then
-            vim.api.nvim_buf_call(buf, function()
-              vim.cmd('silent! keepalt keepjumps noautocmd edit!')
-            end)
-          end
+          rhai_utils.format_buffer(buf)
         end,
       })
 
       pcall(require('which-key').add, {
         { '<leader>cR', group = '[C]ode [R]hai' },
-      })
-
-      vim.api.nvim_create_autocmd('FileType', {
-        pattern = 'rhai',
-        callback = function(ev)
-          local buf = ev.buf
-          local fname = vim.api.nvim_buf_get_name(buf)
-          local root = get_root(fname)
-
-          local function ensure_rhai_file()
-            local file = vim.api.nvim_buf_get_name(buf)
-            if file == '' or not file:match '%.rhai$' then
-              vim.notify('Not a .rhai buffer', vim.log.levels.WARN)
-              return nil
-            end
-            return file
-          end
-
-          local function run_overseer(cmd, args, cwd)
-            local ok, overseer = pcall(require, 'overseer')
-            if not ok then
-              return false
-            end
-            local task = overseer.new_task {
-              cmd = cmd,
-              args = args or {},
-              cwd = cwd or root,
-              components = { 'default' },
-            }
-            task:start()
-            overseer.open { enter = false, direction = 'bottom' }
-            return true
-          end
-
-          local function term_run(cmd, args, cwd)
-            cwd = cwd or root
-            vim.cmd 'botright 12split'
-            local win = vim.api.nvim_get_current_win()
-            local command = vim.list_extend({ cmd }, args or {})
-            vim.fn.termopen(command, { cwd = cwd })
-            vim.api.nvim_set_current_win(win)
-            vim.cmd 'startinsert'
-          end
-
-          local function format_current_buffer()
-            if has_formatter(buf) then
-              vim.lsp.buf.format { bufnr = buf, async = false }
-              return true
-            end
-            local file = ensure_rhai_file()
-            if not file then
-              return false
-            end
-            local ok = cli_fmt(file, root)
-            if ok then
-              vim.api.nvim_buf_call(buf, function()
-                vim.cmd('silent! keepalt keepjumps noautocmd edit!')
-              end)
-            end
-            return ok
-          end
-
-          vim.keymap.set('n', '<leader>cRf', function()
-            format_current_buffer()
-          end, { buffer = buf, desc = '[C]ode [R]hai [F]ormat buffer' })
-
-          vim.keymap.set('n', '<leader>cRF', function()
-            if not rhai_executable() then
-              return
-            end
-            local args = { 'fmt' }
-            if not run_overseer('rhai', args, root) then
-              term_run('rhai', args, root)
-            end
-          end, { buffer = buf, desc = '[C]ode [R]hai [F]ormat workspace' })
-
-          vim.keymap.set('n', '<leader>cRc', function()
-            if not rhai_executable() then
-              return
-            end
-            local args = { 'fmt', '--check' }
-            if not run_overseer('rhai', args, root) then
-              term_run('rhai', args, root)
-            end
-          end, { buffer = buf, desc = '[C]ode [R]hai [C]heck formatting' })
-
-          vim.keymap.set('n', '<leader>cRh', vim.lsp.buf.hover, { buffer = buf, desc = '[C]ode [R]hai [H]over' })
-          vim.keymap.set('n', '<leader>cRg', vim.lsp.buf.definition, { buffer = buf, desc = '[C]ode [R]hai [G]oto def' })
-          vim.keymap.set('n', '<leader>cRn', vim.lsp.buf.rename, { buffer = buf, desc = '[C]ode [R]hai Re[n]ame' })
-          vim.keymap.set({ 'n', 'x' }, '<leader>cRa', vim.lsp.buf.code_action, {
-            buffer = buf,
-            desc = '[C]ode [R]hai Code [A]ction',
-          })
-        end,
       })
     end,
   },

--- a/nvim/lua/custom/plugins/whichkey.lua
+++ b/nvim/lua/custom/plugins/whichkey.lua
@@ -64,6 +64,11 @@ return {
           mode = { 'n' },
         },
         {
+          '<leader>cR',
+          group = '[c]ode [R]hai',
+          mode = { 'n', 'x' },
+        },
+        {
           '<leader>d',
           group = '[d]ocument and dashboard',
         },


### PR DESCRIPTION
## Summary
- recognize Rhai buffers early in init.lua and register a dedicated which-key group
- add a custom Rhai plugin module that wires syntax, Tree-sitter, LSP, formatting, and task runners with direct `vim.keymap.set` bindings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddcfd358308332841d68399ad7d68d