### PR TITLE
Fix Telescope registers mapping

### DIFF
--- a/nvim/lua/custom/plugins/telescope.lua
+++ b/nvim/lua/custom/plugins/telescope.lua
@@ -147,7 +147,7 @@ return {
         desc = '[S]earch [N]eovim files',
       })
 
-      vim.keymap.set('n', 'leader>sR', builtin.registers, { desc = '[S]earch Yanks / [R]egisters' })
+      vim.keymap.set('n', '<leader>sR', builtin.registers, { desc = '[S]earch Yanks / [R]egisters' })
 
       vim.keymap.set('n', '<leader>sS', builtin.lsp_workspace_symbols, { desc = '[S]earch [S]ymbols in workspace' })
     end,


### PR DESCRIPTION
## Summary
- correct the Telescope registers keymap to use the `<leader>` prefix

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68df1e7b5190833280aa1bc94e316d76