### PR TITLE
feat: add aerial outline plugin

### DIFF
--- a/nvim/lua/custom/plugins/aerial.lua
+++ b/nvim/lua/custom/plugins/aerial.lua
@@ -1,0 +1,51 @@
+return {
+  {
+    'stevearc/aerial.nvim',
+    event = 'VeryLazy',
+    dependencies = {
+      'nvim-treesitter/nvim-treesitter',
+      'nvim-telescope/telescope.nvim',
+    },
+    opts = {
+      backends = { 'treesitter', 'lsp' },
+      layout = {
+        default_direction = 'prefer_right',
+        placement = 'edge',
+        max_width = { 40, 0.25 },
+        min_width = 30,
+      },
+      attach_mode = 'global',
+      show_guides = true,
+    },
+    config = function(_, opts)
+      local aerial = require 'aerial'
+      aerial.setup(opts)
+
+      vim.keymap.set('n', '<leader>sa', function()
+        aerial.toggle { focus = true }
+      end, { desc = '[S]ymbols [A]erial toggle' })
+
+      vim.keymap.set('n', '<leader>sj', function()
+        aerial.next { skip_hidden = true }
+      end, { desc = '[S]ymbols Next' })
+
+      vim.keymap.set('n', '<leader>sk', function()
+        aerial.prev { skip_hidden = true }
+      end, { desc = '[S]ymbols Previous' })
+
+      local ok, wk = pcall(require, 'which-key')
+      if ok then
+        wk.add {
+          { '<leader>sa', '[S]ymbols [A]erial toggle', mode = 'n' },
+          { '<leader>sj', '[S]ymbols Next', mode = 'n' },
+          { '<leader>sk', '[S]ymbols Previous', mode = 'n' },
+        }
+      end
+
+      local telescope_ok, telescope = pcall(require, 'telescope')
+      if telescope_ok then
+        telescope.load_extension 'aerial'
+      end
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- add stevearc/aerial.nvim with treesitter and LSP backends configured for the preferred right-edge layout
- define symbol navigation keymaps and register them with which-key
- load the Telescope aerial extension for :Telescope aerial integration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df20bcc5cc8332a43e429ad6464bd9