### PR TITLE
Remove koto_ls parser from base treesitter config

### DIFF
--- a/nvim/lua/custom/plugins/nvim-treesitter.lua
+++ b/nvim/lua/custom/plugins/nvim-treesitter.lua
@@ -21,7 +21,6 @@ return {
         'go',
         'nim',
         'zig',
-        'koto_ls',
       },
       -- Autoinstall languages that are not installed
       auto_install = true,


### PR DESCRIPTION
## Summary
- remove the `koto_ls` entry from the base `ensure_installed` list so only real parsers are requested
- confirm the custom Koto plugin keeps adding the actual `koto` parser

## Testing
- nvim --headless "+TSInstallSync koto" +qa *(fails: `nvim` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e074f154b08332b2bc4885ea823cd5