### PR TITLE
Refine Trouble keymaps to use vim.keymap.set directly

### DIFF
--- a/nvim/lua/custom/plugins/telescope.lua
+++ b/nvim/lua/custom/plugins/telescope.lua
@@ -113,7 +113,7 @@ return {
       })
       -- Diagnostic keymaps
       vim.keymap.set('n', '<leader>sq', vim.diagnostic.setqflist, {
-        desc = '[S]earch [Q]uickfix Diagnostic list',
+        desc = '[S]earch [Q]uickfix diagnostics (Trouble/Bqf)',
       })
 
       -- Slightly advanced example of overriding default behavior and theme

--- a/nvim/lua/custom/plugins/trouble.lua
+++ b/nvim/lua/custom/plugins/trouble.lua
@@ -1,0 +1,104 @@
+return {
+  {
+    'folke/trouble.nvim',
+    cmd = 'Trouble',
+    dependencies = {
+      'nvim-tree/nvim-web-devicons',
+    },
+    opts = {
+      auto_close = true,
+      auto_open = false,
+      auto_preview = false,
+      modes = {
+        diagnostics = {
+          desc = 'Workspace Diagnostics',
+        },
+        buffer_diagnostics = {
+          mode = 'diagnostics',
+          desc = 'Buffer Diagnostics',
+          filter = { buf = 0 },
+        },
+        lsp_references = {
+          desc = 'LSP References',
+          params = {
+            include_declaration = true,
+          },
+        },
+        quickfix = {
+          desc = 'Quickfix List',
+        },
+        loclist = {
+          desc = 'Location List',
+        },
+        todo = {
+          mode = 'todo',
+          desc = 'Todo Comments',
+        },
+      },
+    },
+    config = function(_, opts)
+      local trouble = require 'trouble'
+
+      trouble.setup(opts)
+
+      vim.keymap.set('n', '<leader>xx', function()
+        trouble.toggle 'buffer_diagnostics'
+      end, { desc = '[x] Trouble buffer diagnostics' })
+
+      vim.keymap.set('n', '<leader>xw', function()
+        trouble.toggle 'diagnostics'
+      end, { desc = '[x] Trouble workspace diagnostics' })
+
+      vim.keymap.set('n', '<leader>xr', function()
+        trouble.toggle 'lsp_references'
+      end, { desc = '[x] Trouble LSP references' })
+
+      vim.keymap.set('n', '<leader>xt', function()
+        trouble.toggle 'todo'
+      end, { desc = '[x] Trouble TODOs' })
+
+      vim.keymap.set('n', '<leader>xl', function()
+        trouble.toggle 'loclist'
+      end, { desc = '[x] Trouble location list' })
+
+      vim.keymap.set('n', '<leader>xq', function()
+        trouble.toggle 'quickfix'
+      end, { desc = '[x] Trouble quickfix list' })
+
+      local ok, wk = pcall(require, 'which-key')
+      if ok then
+        wk.add {
+          { '<leader>x', group = '[x] Trouble & lists' },
+        }
+      end
+    end,
+  },
+  {
+    'kevinhwang91/nvim-bqf',
+    event = 'BufReadPost quickfix',
+    opts = {
+      auto_enable = true,
+      auto_resize_height = true,
+      preview = {
+        border = 'rounded',
+        win_height = 14,
+        win_vheight = 10,
+        delay_syntax = 40,
+        show_title = true,
+        show_scroll_bar = true,
+      },
+      func_map = {
+        open = '<CR>',
+        openc = 'o',
+        drop = 'O',
+        split = '<C-x>',
+        vsplit = '<C-v>',
+        tab = 't',
+        ptogglemode = 'zp',
+        ptoggleauto = 'P',
+        pscrollup = '<C-b>',
+        pscrolldown = '<C-f>',
+      },
+    },
+  },
+}

--- a/nvim/lua/custom/plugins/whichkey.lua
+++ b/nvim/lua/custom/plugins/whichkey.lua
@@ -97,6 +97,10 @@ return {
           group = '[t]abs and Toggle',
         },
         {
+          '<leader>x',
+          group = '[x] Trouble & quickfix',
+        },
+        {
           '<leader>U',
           group = '[U]i',
         },


### PR DESCRIPTION
## Summary
- replace the Trouble keybinding helper with direct `vim.keymap.set` calls for each toggleable view

## Testing
- not run (nvim is not available in the container image)

 