### PR TITLE
Refactor Trouble keymaps into extra bindings module

### DIFF
--- a/nvim/lua/custom/plugins/extra_keybinds.lua
+++ b/nvim/lua/custom/plugins/extra_keybinds.lua
@@ -1,6 +1,36 @@
 return (function()
   local rhai_utils = require 'custom.lang.rhai'
 
+  -- Trouble & quickfix bindings
+  local function toggle_trouble(mode)
+    require('lazy').load { plugins = { 'trouble.nvim' } }
+    require('trouble').toggle(mode)
+  end
+
+  vim.keymap.set('n', '<leader>xx', function()
+    toggle_trouble 'buffer_diagnostics'
+  end, { desc = '[x] Trouble buffer diagnostics' })
+
+  vim.keymap.set('n', '<leader>xw', function()
+    toggle_trouble 'diagnostics'
+  end, { desc = '[x] Trouble workspace diagnostics' })
+
+  vim.keymap.set('n', '<leader>xr', function()
+    toggle_trouble 'lsp_references'
+  end, { desc = '[x] Trouble LSP references' })
+
+  vim.keymap.set('n', '<leader>xt', function()
+    toggle_trouble 'todo'
+  end, { desc = '[x] Trouble TODOs' })
+
+  vim.keymap.set('n', '<leader>xl', function()
+    toggle_trouble 'loclist'
+  end, { desc = '[x] Trouble location list' })
+
+  vim.keymap.set('n', '<leader>xq', function()
+    toggle_trouble 'quickfix'
+  end, { desc = '[x] Trouble quickfix list' })
+
   -- NIM
   vim.keymap.set('n', '<leader>npr', function()
     local dir_path = vim.fn.expand '%:p:h'

--- a/nvim/lua/custom/plugins/trouble.lua
+++ b/nvim/lua/custom/plugins/trouble.lua
@@ -40,37 +40,6 @@ return {
       local trouble = require 'trouble'
 
       trouble.setup(opts)
-
-      vim.keymap.set('n', '<leader>xx', function()
-        trouble.toggle 'buffer_diagnostics'
-      end, { desc = '[x] Trouble buffer diagnostics' })
-
-      vim.keymap.set('n', '<leader>xw', function()
-        trouble.toggle 'diagnostics'
-      end, { desc = '[x] Trouble workspace diagnostics' })
-
-      vim.keymap.set('n', '<leader>xr', function()
-        trouble.toggle 'lsp_references'
-      end, { desc = '[x] Trouble LSP references' })
-
-      vim.keymap.set('n', '<leader>xt', function()
-        trouble.toggle 'todo'
-      end, { desc = '[x] Trouble TODOs' })
-
-      vim.keymap.set('n', '<leader>xl', function()
-        trouble.toggle 'loclist'
-      end, { desc = '[x] Trouble location list' })
-
-      vim.keymap.set('n', '<leader>xq', function()
-        trouble.toggle 'quickfix'
-      end, { desc = '[x] Trouble quickfix list' })
-
-      local ok, wk = pcall(require, 'which-key')
-      if ok then
-        wk.add {
-          { '<leader>x', group = '[x] Trouble & lists' },
-        }
-      end
     end,
   },
   {


### PR DESCRIPTION
## Summary
- remove lazy keymap registration from the Trouble plugin setup
- add a helper in the extra keybinds module to lazy-load and toggle Trouble
- recreate the Trouble leader key bindings within the shared keybinds file

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e12dcb4fa08332812ec9efb06de7df