### PR TITLE
Add dropbar breadcrumbs winbar

### DIFF
--- a/nvim/lua/custom/plugins/dropbar.lua
+++ b/nvim/lua/custom/plugins/dropbar.lua
@@ -1,0 +1,49 @@
+return {
+  {
+    'Bekaboo/dropbar.nvim',
+    event = 'VeryLazy',
+    dependencies = {
+      'nvim-tree/nvim-web-devicons',
+      { 'nvim-treesitter/nvim-treesitter', optional = true },
+      { 'MunifTanjim/nui.nvim', optional = true },
+    },
+    config = function()
+      local dropbar = require 'dropbar'
+      local configs = require 'dropbar.configs'
+
+      local default_enable = configs.opts.bar.enable
+      local excluded_filetypes = {
+        help = true,
+        dashboard = true,
+        ['snacks_dashboard'] = true,
+        ['alpha'] = true,
+      }
+
+      dropbar.setup {
+        bar = {
+          enable = function(buf, win, info)
+            buf = vim._resolve_bufnr(buf)
+            if not buf or not vim.api.nvim_buf_is_valid(buf) then
+              return false
+            end
+
+            if vim.bo[buf].buftype == 'terminal' then
+              return false
+            end
+
+            local filetype = vim.api.nvim_get_option_value('filetype', { buf = buf })
+            if excluded_filetypes[filetype] then
+              return false
+            end
+
+            return default_enable(buf, win, info)
+          end,
+        },
+      }
+
+      vim.keymap.set('n', '<leader>sb', function()
+        require('dropbar.api').pick()
+      end, { desc = '[S]earch [B]readcrumbs' })
+    end,
+  },
+}

--- a/nvim/lua/custom/plugins/lsp-ui.lua
+++ b/nvim/lua/custom/plugins/lsp-ui.lua
@@ -20,7 +20,7 @@ return {
           jump_num_shortcut = true,
         },
         symbol_in_winbar = {
-          enable = true,
+          enable = false,
           separator = '  ',
           show_file = true,
           folder_level = 2,

--- a/nvim/lua/custom/plugins/lualine.lua
+++ b/nvim/lua/custom/plugins/lualine.lua
@@ -9,7 +9,18 @@ return {
           theme = 'auto', -- auto picks up current colorscheme
           section_separators = { left = '', right = '' },
           component_separators = '|',
+          globalstatus = true,
+          disabled_filetypes = {
+            winbar = {
+              'dashboard',
+              'snacks_dashboard',
+              'help',
+              'terminal',
+            },
+          },
         },
+        winbar = nil,
+        inactive_winbar = nil,
       }
     end,
   },


### PR DESCRIPTION
## Summary
- add dropbar.nvim with optional dependencies, configure breadcrumbs, and map `<leader>sb`
- disable lspsaga winbar symbols and guard lualine settings so dropbar controls the winbar

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e140f58fd08332b8a55a5cc2d703f1