### PR TITLE
Add Smart Splits and WinShift window tooling

### DIFF
--- a/nvim/lua/custom/plugins/extra_keybinds.lua
+++ b/nvim/lua/custom/plugins/extra_keybinds.lua
@@ -251,16 +251,57 @@ return (function()
     require('conform').format { async = true, lsp_format = 'fallback' }
   end, { desc = '[F]ormat buffer' })
   -- Window Management
-  -- Move between windows
-  vim.keymap.set('n', '<leader>wh', '<C-w>h', { desc = '[w]indows Left' })
-  vim.keymap.set('n', '<leader>wj', '<C-w>j', { desc = '[w]indows Down' })
-  vim.keymap.set('n', '<leader>wk', '<C-w>k', { desc = '[w]indows Up' })
-  vim.keymap.set('n', '<leader>wl', '<C-w>l', { desc = '[w]indows Right' })
-  -- Resize splits
-  vim.keymap.set('n', '<leader>w<Left>', '<C-w><', { desc = '[w]indows Resize ←' })
-  vim.keymap.set('n', '<leader>w<Right>', '<C-w>>', { desc = '[w]indows Resize →' })
-  vim.keymap.set('n', '<leader>w<Up>', '<C-w>+', { desc = '[w]indows Resize ↑' })
-  vim.keymap.set('n', '<leader>w<Down>', '<C-w>-', { desc = '[w]indows Resize ↓' })
+  local function load_smart_splits()
+    require('lazy').load { plugins = { 'smart-splits.nvim' } }
+    return require 'smart-splits'
+  end
+
+  local function load_winshift()
+    require('lazy').load { plugins = { 'winshift.nvim' } }
+    return require 'winshift'
+  end
+
+  -- Move between windows with smart-splits
+  vim.keymap.set('n', '<leader>wh', function()
+    load_smart_splits().move_cursor_left()
+  end, { desc = '[w]indows Focus ← (Smart Split)' })
+  vim.keymap.set('n', '<leader>wj', function()
+    load_smart_splits().move_cursor_down()
+  end, { desc = '[w]indows Focus ↓ (Smart Split)' })
+  vim.keymap.set('n', '<leader>wk', function()
+    load_smart_splits().move_cursor_up()
+  end, { desc = '[w]indows Focus ↑ (Smart Split)' })
+  vim.keymap.set('n', '<leader>wl', function()
+    load_smart_splits().move_cursor_right()
+  end, { desc = '[w]indows Focus → (Smart Split)' })
+
+  -- Resize splits with smart-splits (uppercase for directional resizing)
+  vim.keymap.set('n', '<leader>wH', function()
+    load_smart_splits().resize_left()
+  end, { desc = '[w]indows Resize ← (Smart Split)' })
+  vim.keymap.set('n', '<leader>wJ', function()
+    load_smart_splits().resize_down()
+  end, { desc = '[w]indows Resize ↓ (Smart Split)' })
+  vim.keymap.set('n', '<leader>wK', function()
+    load_smart_splits().resize_up()
+  end, { desc = '[w]indows Resize ↑ (Smart Split)' })
+  vim.keymap.set('n', '<leader>wL', function()
+    load_smart_splits().resize_right()
+  end, { desc = '[w]indows Resize → (Smart Split)' })
+
+  -- Enter WinShift interactive modes for moving or swapping windows
+  vim.keymap.set('n', '<leader>wm', function()
+    load_winshift().cmd_move()
+  end, { desc = '[w]indows [m]ove layout (WinShift)' })
+  vim.keymap.set('n', '<leader>wS', function()
+    load_winshift().cmd_swap()
+  end, { desc = '[w]indows [S]wap layout (WinShift)' })
+
+  -- <C-w> arrow fallbacks for resizing (muscle memory friendly)
+  vim.keymap.set('n', '<leader>w<Left>', '<C-w><', { desc = '[w]indows Resize ← (fallback)' })
+  vim.keymap.set('n', '<leader>w<Right>', '<C-w>>', { desc = '[w]indows Resize → (fallback)' })
+  vim.keymap.set('n', '<leader>w<Up>', '<C-w>+', { desc = '[w]indows Resize ↑ (fallback)' })
+  vim.keymap.set('n', '<leader>w<Down>', '<C-w>-', { desc = '[w]indows Resize ↓ (fallback)' })
   -- Split window
   vim.keymap.set('n', '<leader>wv', '<cmd>vsplit<cr>', { desc = '[w]indows [V]ertical Split' })
   vim.keymap.set('n', '<leader>wb', '<cmd>split<cr>', { desc = '[w]indows Horizontal Split' })

--- a/nvim/lua/custom/plugins/window-tools.lua
+++ b/nvim/lua/custom/plugins/window-tools.lua
@@ -1,0 +1,26 @@
+return {
+  {
+    'mrjones2014/smart-splits.nvim',
+    event = 'VeryLazy',
+    opts = function()
+      local has_tmux = vim.env.TMUX ~= nil and vim.fn.executable 'tmux' == 1
+      return {
+        tmux_integration = has_tmux,
+      }
+    end,
+  },
+  {
+    'sindrets/winshift.nvim',
+    cmd = 'WinShift',
+    opts = {
+      highlight_moving_win = true,
+      focused_hl_group = 'Visual',
+      moving_win_options = {
+        wrap = false,
+        cursorline = true,
+        cursorcolumn = true,
+        colorcolumn = '',
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- add smart-splits and winshift plugins for richer window management, detecting tmux availability for integration
- remap window leader keys to use smart-splits for focus/resize and add WinShift helpers while keeping familiar arrow fallbacks

## Testing
- nvim --headless "+quit" *(fails: `nvim` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e140f91e408332a874704e54d9ad9a