### PR TITLE
Ensure auto-session is configured before session-lens

### DIFF
--- a/nvim/lua/custom/plugins/auto-session.lua
+++ b/nvim/lua/custom/plugins/auto-session.lua
@@ -9,5 +9,12 @@ return {
       auto_session_use_git_branch = true,
       log_level = 'error',
     },
+    config = function(_, opts)
+      -- Explicitly configure auto-session so that the plugin populates its
+      -- `conf` table before other plugins (like session-lens) attempt to read
+      -- from it. Without this, session-lens tries to index `AutoSession.conf`
+      -- and errors because lazy.nvim may not have invoked setup automatically.
+      require('auto-session').setup(opts)
+    end,
   },
 }


### PR DESCRIPTION
## Summary
- explicitly invoke auto-session's setup during plugin configuration so its conf table is populated before session-lens reads it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e156419d108332b8b379cc1a6b2411