### PR TITLE
Add Flash navigation and Neoclip clipboard history picker

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -25,6 +25,20 @@ A starting point for Neovim that is:
 | `<leader>ccU` | Upgrade the crate at the cursor directly to the newest release on crates.io, rewriting the dependency specification to match the latest published version. |
 | `<leader>ccu` | Update the crate at the cursor only within the current semver requirement, keeping compatibility while bumping to the most recent allowed version. |
 
+### Navigation
+
+| Shortcut | Action |
+| --- | --- |
+| `s` / `S` | Trigger `flash.nvim` jump navigation or the Treesitter-powered variant without overriding native `f` / `t` motions. |
+| `<leader>hf` | Start a `flash.nvim` jump while staying alongside the existing Hop leader mappings. |
+| `<leader>hF` | Launch the Treesitter-based Flash search from the hop leader group. |
+
+### Clipboard
+
+| Shortcut | Action |
+| --- | --- |
+| `<leader>sY` | Open the Telescope-powered Neoclip picker to browse clipboard history. |
+
 ## Installation
 
 ### Install Neovim

--- a/nvim/lua/custom/plugins/flash.lua
+++ b/nvim/lua/custom/plugins/flash.lua
@@ -1,0 +1,37 @@
+return {
+  {
+    'folke/flash.nvim',
+    event = 'VeryLazy',
+    opts = {
+      modes = {
+        -- keep native f/t motions intact
+        char = {
+          enabled = false,
+        },
+      },
+    },
+    config = function(_, opts)
+      local flash = require 'flash'
+      flash.setup(opts)
+
+      local map = vim.keymap.set
+      local modes = { 'n', 'x', 'o' }
+
+      map(modes, 's', function()
+        flash.jump()
+      end, { desc = 'Flash jump' })
+
+      map(modes, 'S', function()
+        flash.treesitter()
+      end, { desc = 'Flash Treesitter search' })
+
+      map('n', '<leader>hf', function()
+        flash.jump()
+      end, { desc = '[h]op Flash [f]ind' })
+
+      map('n', '<leader>hF', function()
+        flash.treesitter()
+      end, { desc = '[h]op Flash [F]orest (TS)' })
+    end,
+  },
+}

--- a/nvim/lua/custom/plugins/neoclip.lua
+++ b/nvim/lua/custom/plugins/neoclip.lua
@@ -1,0 +1,24 @@
+return {
+  {
+    'AckslD/nvim-neoclip.lua',
+    event = 'VeryLazy',
+    dependencies = {
+      'nvim-telescope/telescope.nvim',
+      {
+        'tami5/sqlite.lua',
+        module = 'sqlite',
+      },
+    },
+    config = function()
+      require('neoclip').setup {
+        history = 1000,
+        enable_persistent_history = true,
+        continuous_sync = true,
+        enable_macro_history = true,
+        db_path = vim.fn.stdpath 'data' .. '/databases/neoclip.sqlite3',
+        filter = nil,
+        preview = true,
+      }
+    end,
+  },
+}

--- a/nvim/lua/custom/plugins/telescope.lua
+++ b/nvim/lua/custom/plugins/telescope.lua
@@ -64,6 +64,7 @@ return {
       -- Enable Telescope extensions if they are installed
       pcall(require('telescope').load_extension, 'fzf')
       pcall(require('telescope').load_extension, 'ui-select')
+      pcall(require('telescope').load_extension, 'neoclip')
 
       -- See `:help telescope.builtin`
       local builtin = require 'telescope.builtin'
@@ -150,6 +151,10 @@ return {
       vim.keymap.set('n', '<leader>sR', builtin.registers, { desc = '[S]earch Yanks / [R]egisters' })
 
       vim.keymap.set('n', '<leader>sS', builtin.lsp_workspace_symbols, { desc = '[S]earch [S]ymbols in workspace' })
+
+      vim.keymap.set('n', '<leader>sY', function()
+        require('telescope').extensions.neoclip.neoclip()
+      end, { desc = '[S]earch clipboard histor[Y]' })
     end,
   },
 }


### PR DESCRIPTION
## Summary
- add flash.nvim with jump and Treesitter navigation bindings that live alongside existing Hop mappings
- install nvim-neoclip with persistent history support and wire its Telescope extension and keymap
- document the new navigation and clipboard shortcuts in the Neovim README

## Testing
- nvim --headless "+lua print('config ok')" +qa *(fails: `nvim` executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e15a1c39808332860248ab9c0c004b