### PR TITLE
Lazy load nvim DAP setup

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -198,7 +198,6 @@ require('lazy').setup({ {
   },
 })
 
-require 'custom.dap-config'
 
 -- Move this inside config block to ensure it's called AFTER plugin is loaded
 -- COLOR SCHEME — manually comment/uncomment to select the one you want

--- a/nvim/lua/custom/dap-config.lua
+++ b/nvim/lua/custom/dap-config.lua
@@ -104,18 +104,18 @@ dap.configurations.zig = {
   },
 }
 
--- DAP-UI
-require('dapui').setup()
+local dapui = require 'dapui'
+dapui.setup()
 
 -- Auto open/close dap-ui
 dap.listeners.after.event_initialized['dapui_config'] = function()
-  require('dapui').open()
+  dapui.open()
 end
 dap.listeners.before.event_terminated['dapui_config'] = function()
-  require('dapui').close()
+  dapui.close()
 end
 dap.listeners.before.event_exited['dapui_config'] = function()
-  require('dapui').close()
+  dapui.close()
 end
 
 -- 🛠 Rust LLDB Pretty-Printer Injection (Fixed)

--- a/nvim/lua/custom/plugins/dap-ui.lua
+++ b/nvim/lua/custom/plugins/dap-ui.lua
@@ -1,25 +1,10 @@
 return {
   {
     'rcarriga/nvim-dap-ui',
+    lazy = true,
     dependencies = {
       'mfussenegger/nvim-dap',
       'nvim-neotest/nvim-nio',
     },
-    config = function()
-      local dap = require 'dap'
-      local dapui = require 'dapui'
-
-      dapui.setup()
-
-      dap.listeners.after.event_initialized['dapui_config'] = function()
-        dapui.open()
-      end
-      dap.listeners.before.event_terminated['dapui_config'] = function()
-        dapui.close()
-      end
-      dap.listeners.before.event_exited['dapui_config'] = function()
-        dapui.close()
-      end
-    end,
   },
 }

--- a/nvim/lua/custom/plugins/nvim-dap.lua
+++ b/nvim/lua/custom/plugins/nvim-dap.lua
@@ -1,4 +1,16 @@
-return {{
+return {
+  {
     'mfussenegger/nvim-dap',
-    lazy = true
-}}
+    lazy = true,
+    dependencies = {
+      'rcarriga/nvim-dap-ui',
+      'theHamsta/nvim-dap-virtual-text',
+      'nvim-telescope/telescope.nvim',
+      'nvim-telescope/telescope-dap.nvim',
+      'nvim-neotest/nvim-nio',
+    },
+    config = function()
+      require 'custom.dap-config'
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- remove the eager `custom.dap-config` require from `init.lua`
- configure `mfussenegger/nvim-dap` with its UI and telescope dependencies and load the shared config there
- reduce the `dap-ui` spec to a dependency declaration so its setup only runs from the shared config

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e18d3c94608332a85874999dc4415a