### PR TITLE
Handle missing telescope neoclip extension gracefully

### DIFF
--- a/nvim/lua/custom/plugins/neoclip.lua
+++ b/nvim/lua/custom/plugins/neoclip.lua
@@ -9,30 +9,36 @@ return {
         module = 'sqlite',
       },
     },
-    cond = function()
-      local has_sqlite, sqlite = pcall(require, 'sqlite')
-      if not has_sqlite then
-        vim.notify(
-          'nvim-neoclip.lua disabled: sqlite dependency is not available',
-          vim.log.levels.WARN,
-          { title = 'Neoclip' }
-        )
-        return false
-      end
-
-      -- Ensure sqlite module is fully initialised before continuing.
-      if type(sqlite) ~= 'table' then
-        vim.notify(
-          'nvim-neoclip.lua disabled: sqlite dependency did not return a module table',
-          vim.log.levels.WARN,
-          { title = 'Neoclip' }
-        )
-        return false
-      end
-
-      return true
-    end,
     config = function()
+      local function detect_sqlite()
+        local has_sqlite, sqlite = pcall(require, 'sqlite')
+        if not has_sqlite then
+          return false, 'sqlite dependency is not available'
+        end
+
+        if type(sqlite) ~= 'table' then
+          return false, 'sqlite dependency did not return a module table'
+        end
+
+        local has_defs, defs_err = pcall(require, 'sqlite.defs')
+        if not has_defs then
+          local message = defs_err or 'sqlite native bindings failed to load'
+          return false, message
+        end
+
+        return true
+      end
+
+      local sqlite_available, sqlite_error = detect_sqlite()
+
+      if not sqlite_available then
+        vim.notify(
+          'nvim-neoclip.lua: persistent history disabled - ' .. tostring(sqlite_error),
+          vim.log.levels.WARN,
+          { title = 'Neoclip' }
+        )
+      end
+
       local ok, neoclip = pcall(require, 'neoclip')
       if not ok then
         vim.notify(
@@ -43,15 +49,23 @@ return {
         return
       end
 
-      neoclip.setup {
+      local setup_ok, setup_err = pcall(neoclip.setup, {
         history = 1000,
-        enable_persistent_history = true,
-        continuous_sync = true,
+        enable_persistent_history = sqlite_available,
+        continuous_sync = sqlite_available,
         enable_macro_history = true,
         db_path = vim.fn.stdpath 'data' .. '/databases/neoclip.sqlite3',
         filter = nil,
         preview = true,
-      }
+      })
+
+      if not setup_ok then
+        vim.notify(
+          'nvim-neoclip.lua disabled: setup failed - ' .. tostring(setup_err),
+          vim.log.levels.WARN,
+          { title = 'Neoclip' }
+        )
+      end
     end,
   },
 }

--- a/nvim/lua/custom/plugins/neoclip.lua
+++ b/nvim/lua/custom/plugins/neoclip.lua
@@ -9,8 +9,41 @@ return {
         module = 'sqlite',
       },
     },
+    cond = function()
+      local has_sqlite, sqlite = pcall(require, 'sqlite')
+      if not has_sqlite then
+        vim.notify(
+          'nvim-neoclip.lua disabled: sqlite dependency is not available',
+          vim.log.levels.WARN,
+          { title = 'Neoclip' }
+        )
+        return false
+      end
+
+      -- Ensure sqlite module is fully initialised before continuing.
+      if type(sqlite) ~= 'table' then
+        vim.notify(
+          'nvim-neoclip.lua disabled: sqlite dependency did not return a module table',
+          vim.log.levels.WARN,
+          { title = 'Neoclip' }
+        )
+        return false
+      end
+
+      return true
+    end,
     config = function()
-      require('neoclip').setup {
+      local ok, neoclip = pcall(require, 'neoclip')
+      if not ok then
+        vim.notify(
+          'nvim-neoclip.lua disabled: plugin is not installed or failed to load',
+          vim.log.levels.WARN,
+          { title = 'Neoclip' }
+        )
+        return
+      end
+
+      neoclip.setup {
         history = 1000,
         enable_persistent_history = true,
         continuous_sync = true,

--- a/nvim/lua/custom/plugins/neoclip.lua
+++ b/nvim/lua/custom/plugins/neoclip.lua
@@ -33,10 +33,11 @@ return {
 
       if not sqlite_available then
         vim.notify(
-          'nvim-neoclip.lua: persistent history disabled - ' .. tostring(sqlite_error),
+          'nvim-neoclip.lua disabled: sqlite unavailable - ' .. tostring(sqlite_error),
           vim.log.levels.WARN,
           { title = 'Neoclip' }
         )
+        return
       end
 
       local ok, neoclip = pcall(require, 'neoclip')
@@ -51,8 +52,8 @@ return {
 
       local setup_ok, setup_err = pcall(neoclip.setup, {
         history = 1000,
-        enable_persistent_history = sqlite_available,
-        continuous_sync = sqlite_available,
+        enable_persistent_history = true,
+        continuous_sync = true,
         enable_macro_history = true,
         db_path = vim.fn.stdpath 'data' .. '/databases/neoclip.sqlite3',
         filter = nil,

--- a/nvim/lua/custom/plugins/telescope.lua
+++ b/nvim/lua/custom/plugins/telescope.lua
@@ -46,7 +46,9 @@ return {
 
       -- [[ Configure Telescope ]]
       -- See `:help telescope` and `:help telescope.setup()`
-      require('telescope').setup {
+      local telescope = require 'telescope'
+
+      telescope.setup {
         -- You can put your default mappings / updates / etc. in here
         --  All the info you're looking for is in `:help telescope.setup()`
         --
@@ -62,9 +64,9 @@ return {
       }
 
       -- Enable Telescope extensions if they are installed
-      pcall(require('telescope').load_extension, 'fzf')
-      pcall(require('telescope').load_extension, 'ui-select')
-      pcall(require('telescope').load_extension, 'neoclip')
+      pcall(telescope.load_extension, 'fzf')
+      pcall(telescope.load_extension, 'ui-select')
+      local neoclip_ok = pcall(telescope.load_extension, 'neoclip')
 
       -- See `:help telescope.builtin`
       local builtin = require 'telescope.builtin'
@@ -152,9 +154,11 @@ return {
 
       vim.keymap.set('n', '<leader>sS', builtin.lsp_workspace_symbols, { desc = '[S]earch [S]ymbols in workspace' })
 
-      vim.keymap.set('n', '<leader>sY', function()
-        require('telescope').extensions.neoclip.neoclip()
-      end, { desc = '[S]earch clipboard histor[Y]' })
+      if neoclip_ok then
+        vim.keymap.set('n', '<leader>sY', function()
+          telescope.extensions.neoclip.neoclip()
+        end, { desc = '[S]earch clipboard histor[Y]' })
+      end
     end,
   },
 }


### PR DESCRIPTION
## Summary
- cache the Telescope module during setup so extensions can be loaded consistently
- guard loading and keybinding of the neoclip extension so it only runs when available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a0f0c9a48332a5477b7629b35484