### PR TITLE
Add lazy loading for render-markdown.nvim

### DIFF
--- a/nvim/lua/custom/plugins/render-markdown.lua
+++ b/nvim/lua/custom/plugins/render-markdown.lua
@@ -3,6 +3,8 @@ return {{
     dependencies = {'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.nvim'}, -- if you use the mini.nvim suite
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.icons' }, -- if you use standalone mini plugins
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'nvim-tree/nvim-web-devicons' }, -- if you prefer nvim-web-devicons
+    ft = {'markdown', 'rmd', 'markdown.mdx'},
+    cmd = {'RenderMarkdown'},
     ---@module 'render-markdown'
     ---@type render.md.UserConfig
     opts = {}


### PR DESCRIPTION
## Summary
- configure render-markdown.nvim to load only for markdown-related filetypes
- expose the RenderMarkdown command for manual invocation when desired

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1bd150cf48332bb399fba80124717