### PR TITLE
Lazy load nvim-spectre plugin

### DIFF
--- a/nvim/lua/custom/plugins/extra_keybinds.lua
+++ b/nvim/lua/custom/plugins/extra_keybinds.lua
@@ -491,17 +491,22 @@ return (function()
   vim.keymap.set('n', '<space>sb', ':Telescope file_browser path=%":p:h select_buffer=true<CR>', { desc = '[S]earch file [B]rowser' })
   -- Nvim Spectre
 
+  local function spectre()
+    require('lazy').load { plugins = { 'nvim-spectre' } }
+    return require 'spectre'
+  end
+
   vim.keymap.set('n', '<leader>srs', function()
-    require('spectre').toggle()
+    spectre().toggle()
   end, { desc = '[s]earch [r]eplace [s]pectre' })
   vim.keymap.set('n', '<leader>srw', function()
-    require('spectre').open_visual { select_word = true }
+    spectre().open_visual { select_word = true }
   end, { desc = '[s]earch [r]eplace Spectre visual under [w]ord' })
   vim.keymap.set('v', '<leader>srv', function()
-    require('spectre').open_visual()
+    spectre().open_visual()
   end, { desc = '[s]earch [r]eplace Spectre [v]isual' })
   vim.keymap.set('n', '<leader>src', function()
-    require('spectre').open_file_search()
+    spectre().open_file_search()
   end, { desc = '[s]earch [r]eplace Spectre [c]urrent File' })
 
   -- Helper to run a command in Overseer if present, else a terminal split

--- a/nvim/lua/custom/plugins/nvim-spectre.lua
+++ b/nvim/lua/custom/plugins/nvim-spectre.lua
@@ -1,5 +1,6 @@
 return {
   'nvim-pack/nvim-spectre',
+  cmd = 'Spectre',
   dependencies = { 'nvim-lua/plenary.nvim' },
   config = function()
     require('spectre').setup {


### PR DESCRIPTION
## Summary
- configure nvim-spectre to load on the :Spectre command instead of during startup
- update Spectre keymaps to trigger lazy loading before requiring the module

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1bf0eab788332a32e32b7259622c6