### PR TITLE
Defer extra keybind setup until VeryLazy event

### DIFF
--- a/nvim/lua/custom/plugins/extra_keybinds.lua
+++ b/nvim/lua/custom/plugins/extra_keybinds.lua
@@ -1,5 +1,15 @@
-return (function()
+local M = { {}}
+
+local did_setup = false
+
+function M.setup()
+  if did_setup then
+    return
+  end
+  did_setup = true
+
   local rhai_utils = require 'custom.lang.rhai'
+
 
   -- Trouble & quickfix bindings
   local function toggle_trouble(mode)
@@ -834,5 +844,14 @@ return (function()
     vim.notify('Copied path: ' .. file)
   end, { desc = '[Path] Copy full path' })
 
-  return {}
-end)()
+end
+
+vim.api.nvim_create_autocmd('User', {
+  pattern = 'VeryLazy',
+  callback = function()
+    M.setup()
+  end,
+})
+
+return M
+


### PR DESCRIPTION
## Summary
- wrap the extra keybind configuration in a reusable module setup function
- defer initializing the keymaps and Rhai autocmds until the VeryLazy User event
- guard the setup so it only runs once while keeping the original keymap logic intact

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1bfe9eb8c8332a7a7659b206e0a2c