### PR TITLE
Disable mini.surround setup in favor of nvim-surround

### DIFF
--- a/nvim/lua/custom/plugins/mini.lua
+++ b/nvim/lua/custom/plugins/mini.lua
@@ -14,10 +14,11 @@ return {
 
       -- Add/delete/replace surroundings (brackets, quotes, etc.)
       --
-      -- - saiw) - [S]urround [A]dd [I]nner [W]ord [)]Paren
-      -- - sd'   - [S]urround [D]elete [']quotes
-      -- - sr)'  - [S]urround [R]eplace [)] [']
-      require('mini.surround').setup()
+      -- This setup is intentionally disabled because `nvim-surround`
+      -- provides the active surround mappings. Keeping this line
+      -- commented avoids duplicate mappings while retaining the
+      -- reference for future use if desired.
+      -- require('mini.surround').setup()
 
       -- Simple and easy statusline.
       --  You could remove this setup call if you don't like it,


### PR DESCRIPTION
## Summary
- comment out the `mini.surround` setup so only `nvim-surround` provides surround mappings
- document why the Mini module remains disabled to avoid duplicate bindings

## Testing
- nvim --headless "+verbose nmap sa" +qall *(fails: Neovim not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c7fc14ac8332b8b29c703f33fa7d