### PR TITLE
Document lualine as the primary statusline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ MyDotFiles
 
 * Wezterm
 * Neovim
+  * Statusline configuration lives in `nvim/lua/custom/plugins/lualine.lua`. If you
+    prefer the lightweight `mini.statusline`, set `vim.g.custom_enable_mini_statusline = true`
+    before the plugin manager loads to activate the fallback configuration in
+    `nvim/lua/custom/plugins/mini.lua`.

--- a/nvim/lua/custom/plugins/mini.lua
+++ b/nvim/lua/custom/plugins/mini.lua
@@ -20,21 +20,23 @@ return {
       -- reference for future use if desired.
       -- require('mini.surround').setup()
 
-      -- Simple and easy statusline.
-      --  You could remove this setup call if you don't like it,
-      --  and try some other statusline plugin
-      local statusline = require 'mini.statusline'
-      -- set use_icons to true if you have a Nerd Font
-      statusline.setup {
-        use_icons = vim.g.have_nerd_font,
-      }
+      -- `mini.statusline` remains available as an optional fallback, but we
+      -- only configure it when explicitly requested. This prevents duplicate
+      -- statuslines when another provider (like lualine) is enabled.
+      if vim.g.custom_enable_mini_statusline then
+        local statusline = require 'mini.statusline'
+        -- set use_icons to true if you have a Nerd Font
+        statusline.setup {
+          use_icons = vim.g.have_nerd_font,
+        }
 
-      -- You can configure sections in the statusline by overriding their
-      -- default behavior. For example, here we set the section for
-      -- cursor location to LINE:COLUMN
-      ---@diagnostic disable-next-line: duplicate-set-field
-      statusline.section_location = function()
-        return '%2l:%-2v'
+        -- You can configure sections in the statusline by overriding their
+        -- default behavior. For example, here we set the section for
+        -- cursor location to LINE:COLUMN
+        ---@diagnostic disable-next-line: duplicate-set-field
+        statusline.section_location = function()
+          return '%2l:%-2v'
+        end
       end
 
       -- ... and there is more!


### PR DESCRIPTION
## Summary
- guard the mini.statusline configuration behind a flag so lualine remains the default statusline
- document where to adjust the statusline and how to opt into the mini fallback in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e258d7a7e483329c89d3c21424ec11