### PR TITLE
feat: add nerd font aware dap signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ MyDotFiles
     prefer the lightweight `mini.statusline`, set `vim.g.custom_enable_mini_statusline = true`
     before the plugin manager loads to activate the fallback configuration in
     `nvim/lua/custom/plugins/mini.lua`.
+  * Debug breakpoint signs now follow the `kickstart.nvim` approach: Nerd Font glyphs are
+    used when `vim.g.have_nerd_font` is truthy, and simple Unicode icons are used otherwise so
+    the gutter always shows a visible marker.


### PR DESCRIPTION
## Summary
- create diagnostic-colored highlight groups for DAP signs and load glyphs based on Nerd Font availability
- ensure breakpoint and stopped signs always display icons and guard the setup to run once after nvim-dap loads
- document the Nerd Font/fallback gutter icon behavior in the README for future reference

## Testing
- ⚠️ `nvim --headless -u nvim/init.lua +'lua require("lazy").load{plugins={"nvim-dap"}}' +'lua vim.print(vim.fn.sign_getdefined("DapBreakpoint"))' +'qa'` *(fails: `nvim` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e26a5647e88332bee5ec4579cc7365