### PR TITLE
Add autopairs and comment integrations for Neovim

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -33,6 +33,14 @@ A starting point for Neovim that is:
 | `<leader>hf` | Start a `flash.nvim` jump while staying alongside the existing Hop leader mappings. |
 | `<leader>hF` | Launch the Treesitter-based Flash search from the hop leader group. |
 
+### Comment toggles
+
+| Shortcut | Action |
+| --- | --- |
+| `gcc` | Toggle a line comment for the current line. |
+| `gbc` | Toggle a block comment surrounding the current line when supported. |
+| `gc{motion}` | Comment the text covered by the following motion using Treesitter-aware delimiters. |
+
 ## Installation
 
 ### Install Neovim

--- a/nvim/lua/custom/plugins/comment.lua
+++ b/nvim/lua/custom/plugins/comment.lua
@@ -1,0 +1,24 @@
+return {
+  {
+    'numToStr/Comment.nvim',
+    event = { 'BufReadPre', 'BufNewFile' },
+    dependencies = {
+      {
+        'JoosepAlviste/nvim-ts-context-commentstring',
+        opts = {
+          enable_autocmd = false,
+        },
+      },
+    },
+    opts = function()
+      local commentstring = require('ts_context_commentstring.integrations.comment_nvim')
+      return {
+        mappings = {
+          basic = true,
+          extra = false,
+        },
+        pre_hook = commentstring.create_pre_hook(),
+      }
+    end,
+  },
+}

--- a/nvim/lua/custom/plugins/nvim-autopairs.lua
+++ b/nvim/lua/custom/plugins/nvim-autopairs.lua
@@ -1,0 +1,9 @@
+return {
+  {
+    'windwp/nvim-autopairs',
+    event = 'InsertEnter',
+    opts = {
+      check_ts = true,
+    },
+  },
+}

--- a/nvim/lua/custom/plugins/nvim-cmp.lua
+++ b/nvim/lua/custom/plugins/nvim-cmp.lua
@@ -123,6 +123,10 @@ return {
           },
         },
       }
+
+      require('lazy').load { plugins = { 'nvim-autopairs' } }
+      local cmp_autopairs = require 'nvim-autopairs.completion.cmp'
+      cmp.event:on('confirm_done', cmp_autopairs.on_confirm_done())
     end,
   },
 }

--- a/nvim/lua/custom/plugins/nvim-treesitter.lua
+++ b/nvim/lua/custom/plugins/nvim-treesitter.lua
@@ -9,6 +9,7 @@ return {
         'nim_format_string',
         'bash',
         'c',
+        'comment',
         'diff',
         'html',
         'lua',


### PR DESCRIPTION
## Summary
- add windwp/nvim-autopairs with Treesitter-aware pairing and hook it into nvim-cmp confirmations
- install Comment.nvim alongside ts-context-commentstring for smarter comment toggles and ensure the Treesitter comment parser is available
- document the new comment keybinds in the Neovim README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e28af4fc7c8332ae5aa498ee563848