### PR TITLE
Adjust rustaceanvim lazy loading

### DIFF
--- a/nvim/lua/custom/plugins/rustaceanvim.lua
+++ b/nvim/lua/custom/plugins/rustaceanvim.lua
@@ -1,41 +1,39 @@
+local function configure_rustaceanvim()
+  -- Use environment variable to get install path
+  local install_path = vim.fn.expand '$MASON' .. '\\packages\\codelldb'
+  local extension_path = install_path .. '\\extension\\'
+  local codelldb_path = extension_path .. 'adapter\\codelldb.exe'
+  local liblldb_path = extension_path .. 'lldb\\bin\\liblldb.dll'
+  local cfg = require 'rustaceanvim.config'
+
+  vim.g.rustaceanvim = vim.tbl_deep_extend('force', vim.g.rustaceanvim or {}, {
+    dap = {
+      adapter = cfg.get_codelldb_adapter(codelldb_path, liblldb_path),
+    },
+    server = {
+      settings = {
+        ['rust-analyzer'] = {
+          cargo = { allTargets = false, buildScripts = { enable = false } },
+          procMacro = { enable = false },
+          check = { command = 'check', workspace = false },
+          cachePriming = { enable = false },
+          files = { exclude = { 'dist', 'generated' } },
+        },
+      },
+    },
+  })
+end
+
 return {
   { -- RUST
     'mrcjkb/rustaceanvim',
     version = '^5', -- Recommended
-    lazy = false, -- plugin is already lazy
+    ft = { 'rust', 'toml', 'ron' },
     ['rust-analyzer'] = {
       cargo = {
         allFeatures = true,
       },
     },
-    config = function()
-      -- Use environment variable to get install path
-      local install_path = vim.fn.expand '$MASON' .. '\\packages\\codelldb'
-      local extension_path = install_path .. '\\extension\\'
-      local codelldb_path = extension_path .. 'adapter\\codelldb.exe'
-      local liblldb_path = extension_path .. 'lldb\\bin\\liblldb.dll'
-      local cfg = require 'rustaceanvim.config'
-
-      vim.g.rustaceanvim = vim.tbl_deep_extend('force', vim.g.rustaceanvim or {}, {
-        dap = {
-          adapter = cfg.get_codelldb_adapter(codelldb_path, liblldb_path),
-        },
-      })
-
-      -- Example: minimal rustaceanvim settings mirroring the “lighter” RA config
-      vim.g.rustaceanvim = vim.tbl_deep_extend('force', vim.g.rustaceanvim or {}, {
-        server = {
-          settings = {
-            ['rust-analyzer'] = {
-              cargo = { allTargets = false, buildScripts = { enable = false } },
-              procMacro = { enable = false },
-              check = { command = 'check', workspace = false },
-              cachePriming = { enable = false },
-              files = { exclude = { 'dist', 'generated' } },
-            },
-          },
-        },
-      })
-    end,
+    config = configure_rustaceanvim,
   },
 }


### PR DESCRIPTION
## Summary
- lazy-load rustaceanvim on Rust-related filetypes and wrap its configuration in a reusable function
- defer rust DAP configuration until rustaceanvim has been loaded to avoid premature requires

## Testing
 