### PR TITLE
Handle session-lens Telescope load errors

### DIFF
--- a/nvim/lua/custom/plugins/session-lens.lua
+++ b/nvim/lua/custom/plugins/session-lens.lua
@@ -4,7 +4,13 @@ return {
     dependencies = { 'rmagatti/auto-session', 'nvim-telescope/telescope.nvim' },
     config = function()
       require('session-lens').setup {}
-      -- require('telescope').load_extension 'session-lens'
+      local ok, telescope = pcall(require, 'telescope')
+      if not ok then
+        vim.notify('[session-lens] Telescope not available; extension not loaded', vim.log.levels.WARN)
+        return
+      end
+
+      pcall(telescope.load_extension, 'session-lens')
     end,
     keys = {
       { '<leader>sss', '<cmd>Telescope session-lens search_session<cr>', desc = '[S]ession [S]ave [S]witch' },


### PR DESCRIPTION
## Summary
- ensure session-lens loads the Telescope extension with a protected call
- notify when Telescope is unavailable so the dashboard keybind surfaces issues

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2f1dd01788332bf5c12a705dce9c1