### PR TITLE
Add telescope undo extension

### DIFF
--- a/nvim/lua/custom/plugins/telescope.lua
+++ b/nvim/lua/custom/plugins/telescope.lua
@@ -19,6 +19,7 @@ return {
         end,
       },
       { 'nvim-telescope/telescope-ui-select.nvim' }, -- Useful for getting pretty icons, but requires a Nerd Font.
+      'debugloop/telescope-undo.nvim',
       {
         'nvim-tree/nvim-web-devicons',
         enabled = vim.g.have_nerd_font,
@@ -64,6 +65,7 @@ return {
       -- Enable Telescope extensions if they are installed
       pcall(require('telescope').load_extension, 'fzf')
       pcall(require('telescope').load_extension, 'ui-select')
+      pcall(require('telescope').load_extension, 'undo')
 
       pcall(require('telescope').load_extension, 'session-lens')
 
@@ -152,6 +154,9 @@ return {
       vim.keymap.set('n', '<leader>sR', builtin.registers, { desc = '[S]earch Yanks / [R]egisters' })
 
       vim.keymap.set('n', '<leader>sS', builtin.lsp_workspace_symbols, { desc = '[S]earch [S]ymbols in workspace' })
+      vim.keymap.set('n', '<leader>su', function()
+        require('telescope').extensions.undo.undo()
+      end, { desc = '[S]earch [U]ndo history' })
     end,
   },
 }


### PR DESCRIPTION
## Summary
- add the telescope-undo extension as a dependency for Telescope
- load the undo extension when Telescope starts
- provide a <leader>su keymap to open the undo history picker

## Testing
- nvim --headless "+lua require('telescope').load_extension('undo')" +qall *(fails: command not found: nvim)*

------
https://chatgpt.com/codex/tasks/task_e_68e31353770c8332950c277816544b41