### PR TITLE
Update DAP floating window close shortcut

### DIFF
--- a/nvim/lua/custom/dap-config.lua
+++ b/nvim/lua/custom/dap-config.lua
@@ -365,9 +365,10 @@ local function create_floating_window(title, content)
     title_pos = 'center',
   })
 
-  vim.keymap.set('n', 'q', function()
+  -- Use <Esc> so plain `q` is free for macro recording.
+  vim.keymap.set('n', '<Esc>', function()
     vim.api.nvim_win_close(win, true)
-  end, { buffer = buf })
+  end, { buffer = buf, desc = 'Close DAP floating window' })
 
   return buf, win
 end


### PR DESCRIPTION
## Summary
- change the floating debugger popup to close on <Esc> rather than `q`
- add a description explaining why the mapping leaves `q` available for macros

## Testing
- not run (manual verification required)


------
https://chatgpt.com/codex/tasks/task_e_68e572093f188332a872edfde790d2c9