### PR TITLE
Add Treesitter markdown guardrails and troubleshooting notes

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -116,6 +116,37 @@ Minimum filetypes to verify:
 
 Rust is verified separately through `rustaceanvim` instead of the general `vim.lsp.enable()` path.
 
+## Neovim troubleshooting
+
+### Markdown crash triage
+
+If markdown buffers crash with `attempt to call method 'range' (a nil value)`, use this quick triage:
+
+* **Error signature**: `attempt to call method 'range' (a nil value)`
+* **Reproduction trigger**: opening any `*.md` buffer
+* **Involved components**:
+  * `vim.treesitter`
+  * `nvim-treesitter/query_predicates.lua`
+  * `render-markdown.nvim`
+  * `obsidian.nvim`
+
+This usually indicates an API compatibility mismatch between Neovim core, Treesitter query helpers, and markdown rendering integrations.
+
+### Markdown parser/query compatibility policy
+
+Markdown rendering requires compatible Neovim + Treesitter query APIs. If parser/query checks fail, markdown rendering should stay disabled for affected buffers and show a one-time warning.
+
+### Lockfile and known-good tuple
+
+This repository intentionally omits `lazy-lock.json`, so plugin revisions are not pinned here.
+When validating a working markdown stack, record and pin revisions in your own fork/environment.
+Known-good reference tuple captured on 2026-03-31:
+
+* `neovim` tag `v0.10.4` (`ddce846cef04fb49214bc9f8a75900e9a6d45191`)
+* `nvim-treesitter` `7caec274fd19c12b55902a5b795100d21531391f`
+* `render-markdown.nvim` `c7188a8f9d2953696b6303caccbf39c51fa2c1b1`
+* `obsidian.nvim` `14e0427bef6c55da0d63f9a313fd9941be3a2479`
+
 ## Zig ownership (single source of truth)
 
 Zig language-server ownership lives in `lua/custom/plugins/mason.lua` under the `servers.zls` table.

--- a/nvim/lua/custom/plugins/nvim-treesitter.lua
+++ b/nvim/lua/custom/plugins/nvim-treesitter.lua
@@ -2,8 +2,9 @@ return {
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
-    main = 'nvim-treesitter.configs', -- Sets main module to use for opts
-    -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
+    -- Compatibility policy: Markdown rendering integrations require matching
+    -- Neovim + Treesitter query APIs (notably parser/query predicate helpers).
+    -- Guard markdown-dependent modules when parser/query APIs are unavailable.
     opts = {
       ensure_installed = {
         'nim_format_string',
@@ -37,6 +38,38 @@ return {
         disable = { 'ruby' },
       },
     },
+    config = function(_, opts)
+      local ok_parsers, parsers = pcall(require, 'nvim-treesitter.parsers')
+      local markdown_parser_ready = false
+
+      if ok_parsers and type(parsers.has_parser) == 'function' then
+        markdown_parser_ready = parsers.has_parser 'markdown' and parsers.has_parser 'markdown_inline'
+      end
+
+      vim.g.markdown_treesitter_ready = markdown_parser_ready
+
+      if not markdown_parser_ready then
+        opts.highlight = opts.highlight or {}
+        local highlight_disable = opts.highlight.disable or {}
+        if type(highlight_disable) == 'string' then
+          highlight_disable = { highlight_disable }
+        end
+        table.insert(highlight_disable, 'markdown')
+        table.insert(highlight_disable, 'markdown_inline')
+        opts.highlight.disable = highlight_disable
+
+        opts.indent = opts.indent or {}
+        local indent_disable = opts.indent.disable or {}
+        if type(indent_disable) == 'string' then
+          indent_disable = { indent_disable }
+        end
+        table.insert(indent_disable, 'markdown')
+        table.insert(indent_disable, 'markdown_inline')
+        opts.indent.disable = indent_disable
+      end
+
+      require('nvim-treesitter.configs').setup(opts)
+    end,
     -- There are additional nvim-treesitter modules that you can use to interact
     -- with nvim-treesitter. You should go explore a few and see what interests you:
     --

--- a/nvim/lua/custom/plugins/render-markdown.lua
+++ b/nvim/lua/custom/plugins/render-markdown.lua
@@ -1,11 +1,62 @@
-return {{
+return {
+  {
     'MeanderingProgrammer/render-markdown.nvim',
-    dependencies = {'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.nvim'}, -- if you use the mini.nvim suite
+    dependencies = {
+      'nvim-treesitter/nvim-treesitter',
+      'echasnovski/mini.nvim',
+    }, -- if you use the mini.nvim suite
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.icons' }, -- if you use standalone mini plugins
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'nvim-tree/nvim-web-devicons' }, -- if you prefer nvim-web-devicons
-    ft = {'markdown', 'rmd', 'markdown.mdx'},
-    cmd = {'RenderMarkdown'},
+    ft = { 'markdown', 'rmd', 'markdown.mdx' },
+    cmd = { 'RenderMarkdown' },
+    -- Compatibility policy: Markdown rendering requires compatible Neovim +
+    -- Treesitter query APIs. If parser/query support is unavailable, disable
+    -- rendering for the current markdown buffer and warn once.
     ---@module 'render-markdown'
     ---@type render.md.UserConfig
-    opts = {}
-}}
+    opts = {
+      file_types = { 'markdown', 'rmd', 'markdown.mdx' },
+      anti_conceal = {
+        enabled = true,
+      },
+    },
+    config = function(_, opts)
+      local function markdown_parser_available()
+        local ok_parsers, parsers = pcall(require, 'nvim-treesitter.parsers')
+        if not ok_parsers or type(parsers.has_parser) ~= 'function' then
+          return false
+        end
+
+        return parsers.has_parser 'markdown' and parsers.has_parser 'markdown_inline'
+      end
+
+      require('render-markdown').setup(opts)
+
+      local group = vim.api.nvim_create_augroup('render_markdown_parser_guard', { clear = true })
+      vim.api.nvim_create_autocmd('FileType', {
+        group = group,
+        pattern = { 'markdown', 'rmd', 'markdown.mdx' },
+        callback = function(event)
+          if vim.g.markdown_treesitter_ready or markdown_parser_available() then
+            return
+          end
+
+          vim.b[event.buf].render_markdown_enabled = false
+          vim.api.nvim_buf_call(event.buf, function()
+            pcall(vim.cmd, 'silent! RenderMarkdown disable')
+          end)
+
+          if vim.g.render_markdown_parser_warned then
+            return
+          end
+
+          vim.g.render_markdown_parser_warned = true
+          vim.notify(
+            "render-markdown.nvim disabled for markdown buffers: Treesitter markdown parser/query API unavailable.",
+            vim.log.levels.WARN
+          )
+        end,
+      })
+    end,
+  },
+}


### PR DESCRIPTION
### Motivation

- Prevent crashes caused by an API/compatibility mismatch that surfaces as `attempt to call method 'range' (a nil value)` when opening `*.md` buffers. 
- Ensure markdown rendering integrations do not run when the Treesitter markdown parser or query helper APIs are unavailable. 
- Provide a short triage and a known-good plugin/version reference to help reproducible validation. 

### Description

- Add a Neovim troubleshooting section to `nvim/README.md` with the error signature `attempt to call method 'range' (a nil value)`, reproduction trigger `*.md`, involved components (`vim.treesitter`, `nvim-treesitter/query_predicates.lua`, `render-markdown.nvim`, `obsidian.nvim`), a compatibility policy, and a known-good version tuple. 
- Update `nvim/lua/custom/plugins/nvim-treesitter.lua` to keep `ensure_installed` including `markdown` and `markdown_inline`, add a compatibility policy comment, and add a `config` function that uses `pcall(require, 'nvim-treesitter.parsers')` to detect parser availability, sets `vim.g.markdown_treesitter_ready`, and disables markdown-dependent highlight/indent features when parsers are not available before calling `require('nvim-treesitter.configs').setup(opts)`. 
- Update `nvim/lua/custom/plugins/render-markdown.lua` to replace `opts = {}` with an explicit options table, add a compatibility policy comment, and add a `config` function that verifies Treesitter markdown parser availability and installs an autocmd to disable `render-markdown.nvim` per markdown buffer and emit a one-time warning via `vim.notify(..., vim.log.levels.WARN)` when the parser/query APIs are unavailable. 

### Testing

- Attempted an automated headless config load with `nvim --headless "+lua dofile('nvim/lua/custom/plugins/nvim-treesitter.lua')" "+lua dofile('nvim/lua/custom/plugins/render-markdown.lua')" +qa`, but the `nvim` binary is not installed in this environment so the check could not run. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2351dc6c8332b4bac09c96763b9c)