### PR TITLE
Refine Obsidian/render-markdown buffer arbitration

### DIFF
--- a/nvim/lua/custom/plugins/obsidian.lua
+++ b/nvim/lua/custom/plugins/obsidian.lua
@@ -1,16 +1,16 @@
+local markdown_runtime = require 'custom.utils.markdown_runtime'
+
+local workspace_paths = {
+  'C:\\Users\\multi\\My Drive\\Obsidian\\MyNotes',
+}
+
+vim.g.custom_obsidian_workspace_paths = workspace_paths
+
 return {
   'obsidian-nvim/obsidian.nvim',
   version = '*', -- recommended, use latest release instead of latest commit
   lazy = true,
-  ft = 'markdown',
-  -- Replace the above line with this if you only want to load obsidian.nvim for markdown files in your vault:
-  -- event = {
-  --   -- If you want to use the home shortcut '~' here you need to call 'vim.fn.expand'.
-  --   -- E.g. "BufReadPre " .. vim.fn.expand "~" .. "/my-vault/*.md"
-  --   -- refer to `:h file-pattern` for more examples
-  --   "BufReadPre path/to/my-vault/*.md",
-  --   "BufNewFile path/to/my-vault/*.md",
-  -- },
+  event = markdown_runtime.obsidian_events(),
   dependencies = {
     -- Required.
     'nvim-lua/plenary.nvim',
@@ -23,10 +23,13 @@ return {
     workspaces = {
       {
         name = 'personal',
-        path = 'C:\\Users\\multi\\My Drive\\Obsidian\\MyNotes',
+        path = workspace_paths[1],
       },
     },
 
+    -- Crash-signature guard: keep Obsidian scoped to vault buffers only to
+    -- prevent dual activation races with render-markdown async footer/backlink
+    -- handlers in non-vault markdown files.
     -- see below for full list of options 👇
   },
 }

--- a/nvim/lua/custom/plugins/render-markdown.lua
+++ b/nvim/lua/custom/plugins/render-markdown.lua
@@ -1,3 +1,5 @@
+local markdown_runtime = require 'custom.utils.markdown_runtime'
+
 return {
   {
     'MeanderingProgrammer/render-markdown.nvim',
@@ -38,7 +40,9 @@ return {
         pattern = { 'markdown', 'rmd', 'markdown.mdx' },
         callback = function(event)
           if vim.g.markdown_treesitter_ready or markdown_parser_available() then
-            return
+            if markdown_runtime.can_enable_render_markdown(event.buf) then
+              return
+            end
           end
 
           vim.b[event.buf].render_markdown_enabled = false
@@ -46,13 +50,16 @@ return {
             pcall(vim.cmd, 'silent! RenderMarkdown disable')
           end)
 
+          -- Crash-signature guard: avoid render-markdown in Obsidian-managed
+          -- buffers when Obsidian UI/footer/backlink code is active. Dual async
+          -- markdown decorators have triggered races and hard crashes before.
           if vim.g.render_markdown_parser_warned then
             return
           end
 
           vim.g.render_markdown_parser_warned = true
           vim.notify(
-            "render-markdown.nvim disabled for markdown buffers: Treesitter markdown parser/query API unavailable.",
+            'render-markdown.nvim disabled for this markdown buffer due to parser/runtime safety guards.',
             vim.log.levels.WARN
           )
         end,

--- a/nvim/lua/custom/utils/markdown_runtime.lua
+++ b/nvim/lua/custom/utils/markdown_runtime.lua
@@ -1,0 +1,130 @@
+local M = {}
+
+local uv = vim.uv or vim.loop
+
+local DEFAULT_VAULT_PATHS = {
+  'C:/Users/multi/My Drive/Obsidian/MyNotes',
+}
+
+local LARGE_MARKDOWN_LINE_THRESHOLD = 4000
+local LARGE_MARKDOWN_BYTE_THRESHOLD = 512 * 1024
+
+local function normalize_path(path)
+  if type(path) ~= 'string' or path == '' then
+    return nil
+  end
+
+  local expanded = vim.fn.expand(path)
+  if expanded == '' then
+    return nil
+  end
+
+  expanded = expanded:gsub('\\', '/')
+  expanded = expanded:gsub('/+$', '')
+
+  return expanded
+end
+
+local function workspace_paths()
+  local paths = vim.g.custom_obsidian_workspace_paths
+  if type(paths) ~= 'table' or vim.tbl_isempty(paths) then
+    paths = DEFAULT_VAULT_PATHS
+  end
+
+  local normalized = {}
+  for _, path in ipairs(paths) do
+    local value = normalize_path(path)
+    if value then
+      normalized[#normalized + 1] = value
+    end
+  end
+
+  return normalized
+end
+
+function M.obsidian_events()
+  local events = {}
+  for _, path in ipairs(workspace_paths()) do
+    events[#events + 1] = 'BufReadPre ' .. path .. '/**/*.md'
+    events[#events + 1] = 'BufNewFile ' .. path .. '/**/*.md'
+  end
+  return events
+end
+
+function M.is_obsidian_buffer(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local name = normalize_path(vim.api.nvim_buf_get_name(bufnr))
+  if not name then
+    return false
+  end
+
+  for _, path in ipairs(workspace_paths()) do
+    if name == path or name:sub(1, #path + 1) == (path .. '/') then
+      return true
+    end
+  end
+
+  return false
+end
+
+local function has_markdown_injections(bufnr)
+  local ok, parser = pcall(vim.treesitter.get_parser, bufnr, 'markdown')
+  if not ok or not parser or type(parser.children) ~= 'function' then
+    return false
+  end
+
+  return next(parser:children()) ~= nil
+end
+
+function M.should_run(bufnr, key, min_interval_ms)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  min_interval_ms = min_interval_ms or 250
+
+  local now = uv.hrtime() / 1e6
+  vim.b[bufnr].markdown_runtime_last_run = vim.b[bufnr].markdown_runtime_last_run or {}
+
+  local last_run = vim.b[bufnr].markdown_runtime_last_run[key] or 0
+  if now - last_run < min_interval_ms then
+    return false
+  end
+
+  vim.b[bufnr].markdown_runtime_last_run[key] = now
+  return true
+end
+
+function M.can_enable_render_markdown(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+  if not M.should_run(bufnr, 'render_markdown_gate', 50) then
+    return false
+  end
+
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  if line_count > LARGE_MARKDOWN_LINE_THRESHOLD then
+    return false
+  end
+
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  if name ~= '' then
+    local stat = uv.fs_stat(name)
+    if stat and stat.size and stat.size > LARGE_MARKDOWN_BYTE_THRESHOLD then
+      return false
+    end
+  end
+
+  if has_markdown_injections(bufnr) then
+    return false
+  end
+
+  local obsidian_ui_active = vim.b[bufnr].obsidian_ui_active == true
+    or vim.b[bufnr].obsidian_backlinks_active == true
+    or vim.b[bufnr].obsidian_footer_active == true
+
+  if M.is_obsidian_buffer(bufnr) and (obsidian_ui_active or package.loaded['obsidian'] ~= nil) then
+    return false
+  end
+
+  return true
+end
+
+return M


### PR DESCRIPTION
### Motivation

- Prevent dual-activation races between `obsidian.nvim` and `render-markdown.nvim` by scoping Obsidian to vault buffers and centralizing markdown feature arbitration.

### Description

- Replace global `ft = 'markdown'` activation for Obsidian with vault-scoped `BufReadPre`/`BufNewFile` events generated by a new helper `custom.utils.markdown_runtime.obsidian_events()` and wire the workspace path into plugin opts via `vim.g.custom_obsidian_workspace_paths`.
- Add `nvim/lua/custom/utils/markdown_runtime.lua` implementing `is_obsidian_buffer(bufnr)`, `can_enable_render_markdown(bufnr)`, `obsidian_events()`, `should_run()` throttling, and `has_markdown_injections()` to centralize eligibility and debounce logic.
- Update `nvim/lua/custom/plugins/render-markdown.lua` to call `markdown_runtime.can_enable_render_markdown(event.buf)` to skip render-markdown for Obsidian-managed buffers, very large markdown files, buffers with markdown injections, or when per-buffer throttles deny activation, and add explicit crash-signature comments to document the safety guard.
- Update `nvim/lua/custom/plugins/obsidian.lua` to require the shared helper and use `obsidian_events()` to limit plugin load to vault files only.

### Testing

- Attempted a Lua load/syntax check using `lua -e "assert(loadfile('nvim/lua/custom/plugins/obsidian.lua')) ; assert(loadfile('nvim/lua/custom/plugins/render-markdown.lua')); assert(loadfile('nvim/lua/custom/utils/markdown_runtime.lua')); print('lua syntax ok')"`, but it failed because the `lua` binary is not available in this environment.
- Attempted a headless Neovim invocation with `nvim --headless '+lua print("headless ok")' '+qa'`, but it failed because the `nvim` binary is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc423a4f48833299e7870ea53656dd)