### PR TITLE
Add markdown crash-recovery autocmd and :MarkdownRecover command

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -136,6 +136,19 @@ This usually indicates an API compatibility mismatch between Neovim core, Treesi
 
 Markdown rendering requires compatible Neovim + Treesitter query APIs. If parser/query checks fail, markdown rendering should stay disabled for affected buffers and show a one-time warning.
 
+### Markdown crash recovery
+
+A markdown-only autocmd now wraps markdown UI startup (Treesitter + `render-markdown.nvim`) in `pcall` so parser/query crashes do not break editing.
+
+When Neovim detects a Treesitter failure signature (for example `range` nil or query directive errors), it applies a per-buffer fallback:
+
+* Stops Treesitter for the buffer (`vim.treesitter.stop(bufnr)`).
+* Disables `render-markdown.nvim` for that buffer.
+* Forces regular markdown syntax highlighting so basic editing remains available.
+* Emits a single deduplicated warning for that buffer/session with remediation hints (`:TSUpdate`, plugin update, and restart after parser sync).
+
+Use `:MarkdownRecover` to re-attempt enabling Treesitter + render-markdown in the current markdown buffer without reopening Neovim.
+
 ### Lockfile and known-good tuple
 
 This repository intentionally omits `lazy-lock.json`, so plugin revisions are not pinned here.

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -132,6 +132,8 @@ vim.keymap.set('n', '<C-k>', '<C-w><C-k>', {
 
 -- [[ Basic Autocommands ]]
 --  See `:help lua-guide-autocommands`
+require('custom.autocmds.markdown').setup()
+
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
 local lazypath = vim.fn.stdpath 'data' .. '/lazy/lazy.nvim'

--- a/nvim/lua/custom/autocmds/markdown.lua
+++ b/nvim/lua/custom/autocmds/markdown.lua
@@ -1,0 +1,144 @@
+local markdown_runtime = require 'custom.utils.markdown_runtime'
+
+local M = {}
+
+local MARKDOWN_FILETYPES = {
+  markdown = true,
+  rmd = true,
+  ['markdown.mdx'] = true,
+}
+
+local function is_markdown_buf(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return false
+  end
+
+  return MARKDOWN_FILETYPES[vim.bo[bufnr].filetype] == true
+end
+
+local function is_treesitter_failure(err)
+  local message = tostring(err or ''):lower()
+  if message == '' then
+    return false
+  end
+
+  if message:find('range') and message:find('nil') then
+    return true
+  end
+
+  if message:find('directive') then
+    return true
+  end
+
+  return message:find('treesitter') and message:find('query') and message:find('error')
+end
+
+local function notify_once(bufnr, reason)
+  if vim.b[bufnr].markdown_recovery_notified then
+    return
+  end
+
+  vim.b[bufnr].markdown_recovery_notified = true
+  vim.notify(
+    'Markdown UI fallback enabled for this buffer ('
+      .. reason
+      .. '). Treesitter highlighting and render-markdown were disabled. '
+      .. 'Use :MarkdownRecover after running :TSUpdate / plugin updates, then restart Neovim after parser sync if needed.',
+    vim.log.levels.WARN,
+    { title = 'Markdown crash recovery' }
+  )
+end
+
+local function disable_render_markdown(bufnr)
+  vim.b[bufnr].render_markdown_enabled = false
+  vim.api.nvim_buf_call(bufnr, function()
+    pcall(vim.cmd, 'silent! RenderMarkdown disable')
+  end)
+end
+
+local function fallback_to_basic_markdown(bufnr, reason)
+  vim.b[bufnr].markdown_recovery_failed = true
+
+  pcall(vim.treesitter.stop, bufnr)
+  disable_render_markdown(bufnr)
+
+  vim.bo[bufnr].syntax = 'markdown'
+
+  notify_once(bufnr, reason)
+end
+
+local function safe_start_markdown_ui(bufnr)
+  if not is_markdown_buf(bufnr) then
+    return false
+  end
+
+  if vim.b[bufnr].markdown_recovery_failed and not vim.b[bufnr].markdown_recover_requested then
+    return false
+  end
+
+  if not markdown_runtime.can_enable_render_markdown(bufnr) and not vim.b[bufnr].markdown_recover_requested then
+    return false
+  end
+
+  local ok_ts, ts_err = pcall(vim.treesitter.start, bufnr)
+  if not ok_ts and is_treesitter_failure(ts_err) then
+    fallback_to_basic_markdown(bufnr, 'treesitter failure signature')
+    return false
+  end
+
+  local ok_render, render_err = pcall(function()
+    vim.api.nvim_buf_call(bufnr, function()
+      vim.cmd 'silent RenderMarkdown enable'
+    end)
+  end)
+
+  if not ok_render and is_treesitter_failure(render_err) then
+    fallback_to_basic_markdown(bufnr, 'render-markdown treesitter directive failure')
+    return false
+  end
+
+  vim.b[bufnr].markdown_recovery_failed = false
+  vim.b[bufnr].markdown_recover_requested = false
+
+  return true
+end
+
+function M.recover(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  vim.b[bufnr].markdown_recover_requested = true
+
+  local ok = safe_start_markdown_ui(bufnr)
+  if ok then
+    vim.notify('Markdown UI recovery succeeded for current buffer.', vim.log.levels.INFO, { title = 'MarkdownRecover' })
+    return
+  end
+
+  if not vim.b[bufnr].markdown_recovery_failed then
+    vim.notify('MarkdownRecover did not enable markdown UI for this buffer (runtime safety gate).', vim.log.levels.WARN, {
+      title = 'MarkdownRecover',
+    })
+  end
+end
+
+function M.setup()
+  local group = vim.api.nvim_create_augroup('custom_markdown_crash_recovery', { clear = true })
+
+  vim.api.nvim_create_autocmd('FileType', {
+    group = group,
+    pattern = { 'markdown', 'rmd', 'markdown.mdx' },
+    callback = function(event)
+      vim.schedule(function()
+        safe_start_markdown_ui(event.buf)
+      end)
+    end,
+  })
+
+  pcall(vim.api.nvim_del_user_command, 'MarkdownRecover')
+  vim.api.nvim_create_user_command('MarkdownRecover', function()
+    M.recover(vim.api.nvim_get_current_buf())
+  end, {
+    desc = 'Retry Treesitter + render-markdown after markdown crash fallback',
+  })
+end
+
+return M

--- a/nvim/lua/custom/plugins/render-markdown.lua
+++ b/nvim/lua/custom/plugins/render-markdown.lua
@@ -1,5 +1,3 @@
-local markdown_runtime = require 'custom.utils.markdown_runtime'
-
 return {
   {
     'MeanderingProgrammer/render-markdown.nvim',
@@ -7,13 +5,8 @@ return {
       'nvim-treesitter/nvim-treesitter',
       'echasnovski/mini.nvim',
     }, -- if you use the mini.nvim suite
-    -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.icons' }, -- if you use standalone mini plugins
-    -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'nvim-tree/nvim-web-devicons' }, -- if you prefer nvim-web-devicons
     ft = { 'markdown', 'rmd', 'markdown.mdx' },
     cmd = { 'RenderMarkdown' },
-    -- Compatibility policy: Markdown rendering requires compatible Neovim +
-    -- Treesitter query APIs. If parser/query support is unavailable, disable
-    -- rendering for the current markdown buffer and warn once.
     ---@module 'render-markdown'
     ---@type render.md.UserConfig
     opts = {
@@ -23,47 +16,7 @@ return {
       },
     },
     config = function(_, opts)
-      local function markdown_parser_available()
-        local ok_parsers, parsers = pcall(require, 'nvim-treesitter.parsers')
-        if not ok_parsers or type(parsers.has_parser) ~= 'function' then
-          return false
-        end
-
-        return parsers.has_parser 'markdown' and parsers.has_parser 'markdown_inline'
-      end
-
       require('render-markdown').setup(opts)
-
-      local group = vim.api.nvim_create_augroup('render_markdown_parser_guard', { clear = true })
-      vim.api.nvim_create_autocmd('FileType', {
-        group = group,
-        pattern = { 'markdown', 'rmd', 'markdown.mdx' },
-        callback = function(event)
-          if vim.g.markdown_treesitter_ready or markdown_parser_available() then
-            if markdown_runtime.can_enable_render_markdown(event.buf) then
-              return
-            end
-          end
-
-          vim.b[event.buf].render_markdown_enabled = false
-          vim.api.nvim_buf_call(event.buf, function()
-            pcall(vim.cmd, 'silent! RenderMarkdown disable')
-          end)
-
-          -- Crash-signature guard: avoid render-markdown in Obsidian-managed
-          -- buffers when Obsidian UI/footer/backlink code is active. Dual async
-          -- markdown decorators have triggered races and hard crashes before.
-          if vim.g.render_markdown_parser_warned then
-            return
-          end
-
-          vim.g.render_markdown_parser_warned = true
-          vim.notify(
-            'render-markdown.nvim disabled for this markdown buffer due to parser/runtime safety guards.',
-            vim.log.levels.WARN
-          )
-        end,
-      })
     end,
   },
 }


### PR DESCRIPTION
### Motivation

- Prevent markdown UI crashes (Treesitter / render-markdown interaction) from breaking basic editing by providing a safe per-buffer fallback and a recovery path.
- Centralize markdown startup safety checks so plugin-local FileType guards are replaced with a single, maintainable autocmd module.

### Description

- Add a centralized autocmd module at `nvim/lua/custom/autocmds/markdown.lua` that wraps markdown UI startup (`vim.treesitter.start` + `RenderMarkdown enable`) in `pcall` and detects Treesitter failure signatures (e.g. `range` nil / directive/query errors).
- On detected failure the module stops Treesitter for the buffer with `pcall(vim.treesitter.stop, bufnr)`, disables `render-markdown` for that buffer, forces `syntax=markdown` to preserve basic editing, and emits a single deduplicated `vim.notify` warning with remediation hints (`:TSUpdate`, plugin updates, restart after parser sync).
- Add a user command `:MarkdownRecover` that sets a per-buffer retry flag and attempts to re-enable Treesitter + `render-markdown` without reopening Neovim.
- Wire the new module into startup from `nvim/init.lua` and simplify `nvim/lua/custom/plugins/render-markdown.lua` so crash-recovery logic is centralized; document the fallback and recovery behavior in `nvim/README.md` under a new “Markdown crash recovery” subsection.

### Testing

- Verified repository files were updated and a new `nvim/lua/custom/autocmds/markdown.lua` file was created as intended and `nvim/init.lua`, `nvim/lua/custom/plugins/render-markdown.lua`, and `nvim/README.md` were modified.
- Attempted syntax/load checks with `luac -p` but `luac` is not available in the environment so syntax verification could not be completed.
- Attempted to load the new Lua files with a headless `nvim` invocation but `nvim` is not available in the environment so runtime validation could not be performed.
- No automated runtime tests ran due to the missing `nvim` / `luac` binaries; manual verification is recommended in a full Neovim environment (run `:Lua <path>` or `:luafile` and open markdown buffers to exercise `:MarkdownRecover`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc5b2d812083328ef79002d0eeacc9)