### PR TITLE
Add markdown compatibility preflight and reasoned fallback

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -136,6 +136,15 @@ This usually indicates an API compatibility mismatch between Neovim core, Treesi
 
 Markdown rendering requires compatible Neovim + Treesitter query APIs. If parser/query checks fail, markdown rendering should stay disabled for affected buffers and show a one-time warning.
 
+`safe_start_markdown_ui()` now runs a markdown preflight compatibility gate before `vim.treesitter.start()` and quarantines the buffer immediately if the stack is incompatible. The preflight returns structured results with reason codes (`{ ok = false, reason = "<code>" }`) so fallback messages are specific.
+
+Inspect active preflight/fallback reason codes in a markdown buffer with:
+
+```vim
+:echo get(b:, 'markdown_recovery_reason', '')
+:lua vim.print(require('custom.utils.markdown_runtime').markdown_stack_compatible(0))
+```
+
 ### Markdown crash recovery
 
 A markdown-only autocmd now wraps markdown UI startup (Treesitter + `render-markdown.nvim`) in `pcall` so parser/query crashes do not break editing.

--- a/nvim/lua/custom/autocmds/markdown.lua
+++ b/nvim/lua/custom/autocmds/markdown.lua
@@ -88,6 +88,7 @@ end
 
 local function clear_recovery_state(bufnr)
   vim.b[bufnr].markdown_recovery_failed = false
+  vim.b[bufnr].markdown_recovery_reason = nil
   vim.b[bufnr].markdown_recover_requested = false
   vim.b[bufnr].markdown_ts_quarantined = false
   vim.b[bufnr].markdown_recovery_notified = false
@@ -102,6 +103,7 @@ end
 
 fallback_to_basic_markdown = function(bufnr, reason)
   vim.b[bufnr].markdown_recovery_failed = true
+  vim.b[bufnr].markdown_recovery_reason = reason
   vim.b[bufnr].markdown_ts_quarantined = true
 
   pcall(vim.treesitter.stop, bufnr)
@@ -130,6 +132,12 @@ local function safe_start_markdown_ui(bufnr, opts)
   end
 
   if not markdown_runtime.can_enable_render_markdown(bufnr) and not explicit_recover then
+    return false
+  end
+
+  local compatibility = markdown_runtime.markdown_stack_compatible(bufnr)
+  if not compatibility.ok then
+    fallback_to_basic_markdown(bufnr, 'compatibility preflight: ' .. compatibility.reason)
     return false
   end
 
@@ -168,7 +176,8 @@ function M.recover(bufnr)
   end
 
   if not vim.b[bufnr].markdown_recovery_failed then
-    vim.notify('MarkdownRecover did not enable markdown UI for this buffer (runtime safety gate).', vim.log.levels.WARN, {
+    local reason = vim.b[bufnr].markdown_recovery_reason or 'runtime safety gate'
+    vim.notify('MarkdownRecover did not enable markdown UI for this buffer (' .. reason .. ').', vim.log.levels.WARN, {
       title = 'MarkdownRecover',
     })
   end

--- a/nvim/lua/custom/utils/markdown_runtime.lua
+++ b/nvim/lua/custom/utils/markdown_runtime.lua
@@ -127,4 +127,78 @@ function M.can_enable_render_markdown(bufnr)
   return true
 end
 
+function M.markdown_stack_compatible(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+  local function fail(reason)
+    return { ok = false, reason = reason }
+  end
+
+  if type(vim.treesitter) ~= 'table' then
+    return fail 'missing_treesitter_runtime'
+  end
+
+  if type(vim.treesitter.start) ~= 'function' then
+    return fail 'missing_treesitter_start'
+  end
+
+  if type(vim.treesitter.get_parser) ~= 'function' then
+    return fail 'missing_treesitter_get_parser'
+  end
+
+  if type(vim.treesitter.query) ~= 'table' then
+    return fail 'missing_treesitter_query_module'
+  end
+
+  local query = vim.treesitter.query
+  if type(query.get) ~= 'function' then
+    return fail 'missing_query_get'
+  end
+  if type(query.parse) ~= 'function' then
+    return fail 'missing_query_parse'
+  end
+  if type(query.add_predicate) ~= 'function' then
+    return fail 'missing_query_add_predicate'
+  end
+  if type(query.add_directive) ~= 'function' then
+    return fail 'missing_query_add_directive'
+  end
+
+  for _, language in ipairs { 'markdown', 'markdown_inline' } do
+    local ok_parser, parser = pcall(vim.treesitter.get_parser, bufnr, language)
+    if not ok_parser or parser == nil then
+      return fail('missing_parser_' .. language)
+    end
+
+    if type(parser.parse) ~= 'function' then
+      return fail('missing_parser_parse_' .. language)
+    end
+
+    local ok_parse, trees = pcall(parser.parse, parser)
+    if not ok_parse or type(trees) ~= 'table' or trees[1] == nil then
+      return fail('parser_parse_failed_' .. language)
+    end
+
+    local tree = trees[1]
+    if type(tree.root) ~= 'function' then
+      return fail('missing_tree_root_' .. language)
+    end
+
+    local ok_root, root = pcall(tree.root, tree)
+    if not ok_root or root == nil then
+      return fail('tree_root_failed_' .. language)
+    end
+
+    if type(root.range) ~= 'function' then
+      return fail('missing_node_range_' .. language)
+    end
+
+    if not pcall(root.range, root) then
+      return fail('node_range_call_failed_' .. language)
+    end
+  end
+
+  return { ok = true, reason = 'ok' }
+end
+
 return M


### PR DESCRIPTION
### Motivation

- Prevent crashes stemming from API incompatibilities between Neovim core, nvim-treesitter query helpers, and markdown renderers by gating markdown UI startup with a focused compatibility preflight.

### Description

- Add `markdown_stack_compatible(bufnr)` in `nvim/lua/custom/utils/markdown_runtime.lua` which returns a structured `{ ok, reason }` and validates Treesitter/query runtime surfaces, `markdown`/`markdown_inline` parsers, query predicate/directive helpers, and the `node:range()` call path. 
- Integrate the preflight into `safe_start_markdown_ui()` so the compatibility gate runs before `vim.treesitter.start()` and incompatible stacks are quarantined immediately with a reason code. 
- Persist per-buffer fallback reason in `b:markdown_recovery_reason`, clear it on successful recovery, and surface it in `:MarkdownRecover` warning output for clearer operator feedback. 
- Document the new preflight gate and inspection commands in the README `Markdown crash triage` section. 

### Testing

- Ran `git diff --check` to validate there are no obvious diff/whitespace issues and it passed. 
- Attempted Lua syntax validation with `luac -p nvim/lua/custom/utils/markdown_runtime.lua && luac -p nvim/lua/custom/autocmds/markdown.lua` but `luac` is not installed in this environment so the syntax check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc68b3232483328a0335623a65e600)