### PR TITLE
feat(nvim): shared notify config for nvim-notify and noice

### DIFF
--- a/nvim/lua/custom/config/notify.lua
+++ b/nvim/lua/custom/config/notify.lua
@@ -1,0 +1,35 @@
+local M = {}
+
+local defaults = {
+  timeout = 3000,
+  stages = 'fade_in_slide_out',
+  render = 'default',
+  background_colour = '#000000',
+  top_down = true,
+  fps = 60,
+  minimum_width = 20,
+  minimum_height = 1,
+  max_width = 120,
+  max_height = 20,
+}
+
+local function normalize_global_opts(value)
+  if type(value) == 'table' then
+    return value
+  end
+
+  return {}
+end
+
+function M.defaults()
+  return vim.deepcopy(defaults)
+end
+
+function M.resolve(overrides)
+  local global_overrides = normalize_global_opts(vim.g.custom_notify_opts)
+  local local_overrides = type(overrides) == 'table' and overrides or {}
+
+  return vim.tbl_deep_extend('force', M.defaults(), global_overrides, local_overrides)
+end
+
+return M

--- a/nvim/lua/custom/config/notify.lua
+++ b/nvim/lua/custom/config/notify.lua
@@ -2,8 +2,8 @@ local M = {}
 
 local defaults = {
   timeout = 3000,
-  stages = 'fade_in_slide_out',
-  render = 'default',
+  stages = 'fade_in_slide_out', -- also: 'fade', 'slide', 'static', 'fade_in_slide_out'
+  render = 'default', -- also: 'minimal', 'simple', 'compact', 'wrapped-compact'
   background_colour = '#000000',
   top_down = true,
   fps = 60,

--- a/nvim/lua/custom/plugins/noice.lua
+++ b/nvim/lua/custom/plugins/noice.lua
@@ -11,6 +11,7 @@ return {
     },
     opts = function()
       local border = 'rounded'
+      local notify_opts = require('custom.config.notify').resolve()
 
       return {
         cmdline = {
@@ -32,6 +33,11 @@ return {
           lsp_doc_border = true,
         },
         views = {
+          notify = {
+            replace = true,
+            merge = true,
+            top_down = notify_opts.top_down,
+          },
           cmdline_popup = {
             border = {
               style = border,

--- a/nvim/lua/custom/plugins/nvim-notify.lua
+++ b/nvim/lua/custom/plugins/nvim-notify.lua
@@ -2,8 +2,21 @@ return {
 
   {
     'rcarriga/nvim-notify',
-    config = function()
-      vim.notify = require 'notify'
+    config = function(_, opts)
+      local notify_opts = require('custom.config.notify').resolve(opts)
+      local ok, notify = pcall(require, 'notify')
+      if not ok then
+        local fallback = '[nvim-notify] plugin unavailable; using built-in vim.notify'
+        if vim.api and vim.api.nvim_echo then
+          vim.api.nvim_echo({ { fallback, 'WarningMsg' } }, true, {})
+        else
+          print(fallback)
+        end
+        return
+      end
+
+      notify.setup(notify_opts)
+      vim.notify = notify
     end,
   },
 }


### PR DESCRIPTION
### Motivation
- Centralize notification defaults so both `rcarriga/nvim-notify` and `folke/noice.nvim` share the same behavior and appearance.
- Allow users to override notify settings without editing plugin files by supporting a global override table `vim.g.custom_notify_opts` and per-plugin options.
- Ensure Noice's `messages.view = 'notify'` route remains visually consistent with `nvim-notify` settings (ordering, stages, etc.).

### Description
- Add a shared config module at `nvim/lua/custom/config/notify.lua` that exports defaults and a `resolve` function which merges `M.defaults()`, `vim.g.custom_notify_opts`, and any plugin-provided options.
- Default options include `timeout`, `stages`, `render`, `background_colour`, `top_down`, `fps`, and size constraints (`minimum_width`, `minimum_height`, `max_width`, `max_height`).
- Update `nvim/lua/custom/plugins/nvim-notify.lua` to call `require('custom.config.notify').resolve(opts)`, defensively `pcall(require, 'notify')`, call `notify.setup(merged_opts)`, and then set `vim.notify = notify`, emitting a concise fallback using `vim.api.nvim_echo` or `print` if the plugin is unavailable.
- Update `nvim/lua/custom/plugins/noice.lua` to `require('custom.config.notify').resolve()` and wire `views.notify` options (`replace`, `merge`, `top_down`) so Noice's notify-based views align with the shared settings while keeping `messages.view = 'notify'` intact.

### Testing
- Ran an automated search to verify references and wiring with `rg -n "custom.config.notify|pcall(require, 'notify')|view = 'notify'|vim.notify = notify" nvim/lua/custom/plugins nvim/lua/custom/config`, which found the updated usages and succeeded.
- Attempted a Lua syntax check with `luac -p nvim/lua/custom/config/notify.lua nvim/lua/custom/plugins/nvim-notify.lua nvim/lua/custom/plugins/noice.lua`, which could not run because `luac` is not installed in this environment (validation not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6bc0d2848332ad408e5b1e630240)