### PR TITLE
Add shared pre-save guard before external command launches

### DIFF
--- a/nvim/ftplugin/koto.lua
+++ b/nvim/ftplugin/koto.lua
@@ -1,5 +1,6 @@
 -- ftplugin/koto.lua
 local buf = vim.api.nvim_get_current_buf()
+local save_utils = require 'custom.utils.save'
 
 -- Optional: Which-Key v3 group (safe no-op if wk missing/old)
 local function add_wk_group(target_buf)
@@ -31,6 +32,9 @@ end
 
 -- Prefer Overseer if available; fallback to terminal split otherwise
 local function run_overseer(cmd, args, cwd)
+  if not save_utils.write_all() then
+    return false
+  end
   local ok, overseer = pcall(require, 'overseer')
   if not ok then
     return false
@@ -42,6 +46,9 @@ local function run_overseer(cmd, args, cwd)
 end
 
 local function term_run(cmdline)
+  if not save_utils.write_all() then
+    return
+  end
   vim.cmd('botright 12split | terminal ' .. cmdline)
   vim.cmd 'startinsert'
 end

--- a/nvim/lua/custom/dap-config.lua
+++ b/nvim/lua/custom/dap-config.lua
@@ -1,4 +1,5 @@
 local dap = require 'dap'
+local save_utils = require 'custom.utils.save'
 
 local rust_dap_initialized = false
 
@@ -80,6 +81,9 @@ dap.configurations.rust = {
     type = 'codelldb', --rust
     request = 'launch',
     program = function()
+      if not save_utils.write_all() then
+        return nil
+      end
       local uv = vim.uv or vim.loop
       local cwd = vim.fn.getcwd()
       local exe_name = vim.fn.fnamemodify(cwd, ':t')
@@ -160,6 +164,9 @@ dap.configurations.zig = {
     type = 'codelldb',
     request = 'launch',
     program = function()
+      if not save_utils.write_all() then
+        return nil
+      end
       -- Build a temporary exe for the current file, then debug it
       local src = vim.fn.expand '%:p'
       local out = vim.fn.fnamemodify(src, ':r') .. '.exe'
@@ -251,6 +258,9 @@ vim.fn.sign_define('DapBreakpointCondition', { text = '🔵', texthl = '', lineh
 local map = vim.keymap.set
 
 map('n', '<leader>cdd', function()
+  if not save_utils.write_all() then
+    return
+  end
   dap.continue()
 end, { desc = '[C]ode [D]ebug Start/Continue' })
 map('n', '<leader>cdt', function()

--- a/nvim/lua/custom/lang/rhai.lua
+++ b/nvim/lua/custom/lang/rhai.lua
@@ -1,4 +1,5 @@
 local M = {}
+local save_utils = require 'custom.utils.save'
 
 local function get_lsp_util()
   local ok, util = pcall(require, 'lspconfig.util')
@@ -107,6 +108,9 @@ function M.format_buffer(bufnr)
 end
 
 function M.run_overseer(cmd, args, cwd)
+  if not save_utils.write_all() then
+    return false
+  end
   local ok, overseer = pcall(require, 'overseer')
   if not ok then
     return false
@@ -123,6 +127,9 @@ function M.run_overseer(cmd, args, cwd)
 end
 
 function M.term_run(cmd, args, cwd)
+  if not save_utils.write_all() then
+    return
+  end
   cwd = cwd or vim.fn.getcwd()
   vim.cmd 'botright 12split'
   local win = vim.api.nvim_get_current_win()

--- a/nvim/lua/custom/plugins/koto.lua
+++ b/nvim/lua/custom/plugins/koto.lua
@@ -32,6 +32,7 @@ return {
     'neovim/nvim-lspconfig', -- only for utilities; we won't call the deprecated root
     lazy = false,
     init = function()
+      local save_utils = require 'custom.utils.save'
       -- Make sure *.koto is recognized
       vim.filetype.add { extension = { koto = 'koto' } }
 
@@ -112,6 +113,9 @@ return {
 
           -- try Overseer first; fall back to a bottom terminal split
           local function run_overseer(cmd, args, cwd)
+            if not save_utils.write_all() then
+              return false
+            end
             local ok, overseer = pcall(require, 'overseer')
             if not ok then
               return false
@@ -128,6 +132,9 @@ return {
           end
 
           local function term_run(cmdline)
+            if not save_utils.write_all() then
+              return
+            end
             vim.cmd('botright 12split | terminal ' .. cmdline)
             vim.cmd 'startinsert'
           end

--- a/nvim/lua/custom/utils/save.lua
+++ b/nvim/lua/custom/utils/save.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+function M.write_all(opts)
+  opts = opts or {}
+  local ok, err = pcall(vim.cmd, 'wall')
+  if ok then
+    return true
+  end
+
+  if not opts.silent then
+    vim.notify(('Failed to save all buffers before execution: %s'):format(err), vim.log.levels.WARN)
+  end
+  return false
+end
+
+return M


### PR DESCRIPTION
### Motivation
- Ensure buffers are saved before launching external run/build/test commands so debug and run flows operate on current source. 
- Centralize save semantics to avoid repeating `:wall` checks scattered across helpers. 
- Make sure DAP flows that invoke builds (`cargo build`, `zig build-exe`) and the start/continue mapping save first to avoid debugging stale binaries. 

### Description
- Add `nvim/lua/custom/utils/save.lua` exposing `write_all()` which runs `:wall` and notifies on failure. 
- Prepend calls to `require('custom.utils.save').write_all()` in Koto launch helpers in `nvim/ftplugin/koto.lua` and `nvim/lua/custom/plugins/koto.lua` before `run_overseer` and terminal fallbacks. 
- Prepend the shared save call in Rhai helpers in `nvim/lua/custom/lang/rhai.lua` for `run_overseer` and terminal runners. 
- Ensure DAP config in `nvim/lua/custom/dap-config.lua` invokes the save utility before Rust smart-build resolution, Zig current-file `build-exe` flow, and the `<leader>cdd` start/continue mapping while preserving existing Overseer-first / terminal fallback behavior. 

### Testing
- Scanned the modified code paths with `rg` to confirm `write_all` was added and referenced in the targeted helpers. 
- Ran `git diff --check` which reported no whitespace or diff-check issues. 
- Attempted Lua bytecode checks with `luac -p`, but `luac` is not available in this environment so those checks were not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7b13ff4c8332b015f1901c935978)