### PR TITLE
docs(vim-go): add quick command cheat sheet comments

### DIFF
--- a/nvim/lua/custom/plugins/vim-go.lua
+++ b/nvim/lua/custom/plugins/vim-go.lua
@@ -1,4 +1,13 @@
 -- lua/custom/plugins/vim-go.lua
+-- vim-go command cheat sheet:
+-- - :GoRun — run the current file/package entrypoint.
+-- - :GoTest / :GoTestFunc / :GoTestFile — run tests for package, function, or file scope.
+-- - :GoBuild / :GoInstall — compile current package or compile-and-install it.
+-- - :GoFmt / :GoImports — format code and normalize imports.
+-- - :GoDef / :GoDoc / :GoImplements / :GoReferrers — jump to defs/docs and inspect relationships.
+-- - :GoRename — rename symbol references through supported backend.
+-- - :GoDebugStart / :GoDebugTest / :GoDebugContinue — start and control debugger session flow.
+-- - :GoMetaLinter — run configured lint checks for current package.
 return {
   {
     'fatih/vim-go',


### PR DESCRIPTION
### Motivation
- Make common `vim-go` commands easy to discover by adding a concise cheat-sheet comment block near the top of the plugin file.

### Description
- Insert a comments-only cheat sheet in `nvim/lua/custom/plugins/vim-go.lua` listing `:GoRun`, `:GoTest`/`:GoTestFunc`/`:GoTestFile`, `:GoBuild`/`:GoInstall`, `:GoFmt`/`:GoImports`, `:GoDef`/`:GoDoc`/`:GoImplements`/`:GoReferrers`, `:GoRename`, `:GoDebugStart`/`:GoDebugTest`/`:GoDebugContinue`, and `:GoMetaLinter` with one-line purpose text and no behavior changes.

### Testing
- No automated tests were run because this is a comments-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce89032ad88332b3755972815dbb22)