### PR TITLE
Tune cmdline nvim-cmp behavior for Noice popupmenu UX

### DIFF
--- a/nvim/after/ftplugin/autohotkey.lua
+++ b/nvim/after/ftplugin/autohotkey.lua
@@ -1,2 +1,1 @@
-require('custom.ahk2').setup()
 vim.bo.commentstring = '; %s'

--- a/nvim/lua/custom/ahk2.lua
+++ b/nvim/lua/custom/ahk2.lua
@@ -1,58 +1,128 @@
 local M = {}
 
--- Allow overrides from vim.g or environment variables if you want
-local function get(k, default)
-  return vim.g[k] or vim.env[string.upper(k)] or default
+local uv = vim.uv or vim.loop
+
+local function get(name, default)
+  return vim.g[name] or vim.env[name:upper()] or default
 end
 
+local function expand(path)
+  if not path or path == '' then
+    return nil
+  end
+  return vim.fn.expand(path)
+end
+
+local function file_exists(path)
+  path = expand(path)
+  return path and uv.fs_stat(path) ~= nil or false
+end
+
+-- Easy-to-edit defaults for different computers.
+-- You can also override these with:
+--   vim.g.ahk2_node
+--   vim.g.ahk2_server
+--   vim.g.ahk2_exe
+-- or env vars:
+--   AHK2_NODE / AHK2_SERVER / AHK2_EXE
 M.paths = {
   node = get('ahk2_node', [[C:\tools\node-portable\node.exe]]),
-  server = get('ahk2_server', vim.fn.expand [[C:\Tools\vscode-autohotkey2-lsp\server\dist\server.js]]),
-  ahk_exe = get('ahk2_exe', [["C:\Program Files\AutoHotkey\v2\AutoHotkey64.exe"]]),
+  server = get('ahk2_server', [[C:\Tools\vscode-autohotkey2-lsp\server\dist\server.js]]),
+  ahk_exe = get('ahk2_exe', [[C:\Program Files\AutoHotkey\v2\AutoHotkey64.exe]]),
 }
 
-local function exists(p)
-  return p and vim.loop.fs_stat(p) ~= nil
+local function resolve_node()
+  local candidates = {
+    M.paths.node,
+    'node',
+  }
+
+  for _, candidate in ipairs(candidates) do
+    local expanded = expand(candidate)
+    if expanded and file_exists(expanded) then
+      return expanded
+    end
+    if candidate and vim.fn.executable(candidate) == 1 then
+      return candidate
+    end
+  end
+
+  return nil
 end
 
-function M.setup(opts)
-  local ok_lsp, lspconfig = pcall(require, 'lspconfig')
-  if not ok_lsp then
-    return
-  end
-  local configs = require 'lspconfig.configs'
-  local util = require 'lspconfig.util'
+local function resolve_server()
+  local candidates = {
+    M.paths.server,
+    vim.fn.expand '~/vscode-autohotkey2-lsp/server/dist/server.js',
+    [[C:\Tools\vscode-autohotkey2-lsp\server\dist\server.js]],
+  }
 
-  local p = vim.tbl_deep_extend('force', M.paths, opts or {})
-
-  if not exists(p.node) then
-    vim.notify('AHK LSP: node not found at ' .. p.node, vim.log.levels.ERROR)
-    return
-  end
-  if not exists(p.server) then
-    vim.notify('AHK LSP: server not found at ' .. p.server, vim.log.levels.ERROR)
-    return
+  for _, path in ipairs(candidates) do
+    path = expand(path)
+    if file_exists(path) then
+      return path
+    end
   end
 
-  if not configs.ahk2 then
-    configs.ahk2 = {
-      default_config = {
-        cmd = { p.node, p.server, '--stdio' },
-        cmd_cwd = vim.fn.fnamemodify(p.server, ':h'),
-        filetypes = { 'autohotkey', 'ahk', 'ah2' },
-        single_file_support = true,
-        root_dir = function(fname)
-          return util.path.dirname(util.path.sanitize(fname))
-        end,
-        init_options = {
-          locale = 'en-us',
-          InterpreterPath = p.ahk_exe,
-        },
-      },
-    }
+  return nil
+end
+
+local function resolve_ahk_exe()
+  local candidates = {
+    M.paths.ahk_exe,
+    [[C:\Program Files\AutoHotkey\v2\AutoHotkey64.exe]],
+    [[C:\Program Files\AutoHotkey\v2\AutoHotkey.exe]],
+  }
+
+  for _, path in ipairs(candidates) do
+    path = expand(path)
+    if file_exists(path) then
+      return path
+    end
   end
 
-  lspconfig.ahk2.setup {}
+  return nil
+end
+
+function M.build_config()
+  local node = resolve_node()
+  if not node then
+    return nil, 'AHK LSP: could not find Node.js. Set vim.g.ahk2_node or AHK2_NODE.'
+  end
+
+  local server = resolve_server()
+  if not server then
+    return nil, 'AHK LSP: could not find server.js. Set vim.g.ahk2_server or AHK2_SERVER.'
+  end
+
+  local ahk_exe = resolve_ahk_exe()
+  if not ahk_exe then
+    return nil, 'AHK LSP: could not find AutoHotkey v2 exe. Set vim.g.ahk2_exe or AHK2_EXE.'
+  end
+
+  M.paths.node = node
+  M.paths.server = server
+  M.paths.ahk_exe = ahk_exe
+
+  return {
+    cmd = { node, server, '--stdio' },
+    cmd_cwd = vim.fs.dirname(server),
+    filetypes = { 'autohotkey', 'ahk', 'ah2' },
+    single_file_support = true,
+    root_dir = function(bufnr, on_dir)
+      local name = vim.api.nvim_buf_get_name(bufnr)
+      if name == '' then
+        return
+      end
+
+      local root = vim.fs.root(name, { '.git' })
+      on_dir(root or vim.fs.dirname(name))
+    end,
+    init_options = {
+      locale = 'en-us',
+      InterpreterPath = ahk_exe,
+    },
+  }
 end
 
 return M

--- a/nvim/lua/custom/plugins/ahk.lua
+++ b/nvim/lua/custom/plugins/ahk.lua
@@ -1,7 +1,0 @@
-return {
-  'neovim/nvim-lspconfig',
-  ft = { 'ahk', 'autohotkey', 'ah2' },
-  config = function()
-    require('custom.ahk2').setup()
-  end,
-}

--- a/nvim/lua/custom/plugins/mason.lua
+++ b/nvim/lua/custom/plugins/mason.lua
@@ -194,14 +194,21 @@ return {
         automatic_enable = false,
       }
 
+      local has_lsp_enable = type(vim.lsp.config) == 'function' and type(vim.lsp.enable) == 'function'
+      local lspconfig = has_lsp_enable and nil or require 'lspconfig'
+
       for name, cfg in pairs(servers) do
         local server_name = normalize_server_name(name)
         local merged_config = vim.tbl_deep_extend('force', {
           capabilities = vim.tbl_deep_extend('force', {}, capabilities),
         }, cfg or {})
 
-        vim.lsp.config(server_name, merged_config)
-        vim.lsp.enable(server_name)
+        if has_lsp_enable then
+          vim.lsp.config(server_name, merged_config)
+          vim.lsp.enable(server_name)
+        else
+          lspconfig[server_name].setup(merged_config)
+        end
       end
     end,
   },

--- a/nvim/lua/custom/plugins/mason.lua
+++ b/nvim/lua/custom/plugins/mason.lua
@@ -134,7 +134,12 @@ return {
       local util = require 'lspconfig.util' -- safe submodule for root helpers
 
       local servers = {
-        gopls = {},
+        gopls = {
+          root_dir = function(fname)
+            return util.root_pattern('go.work', 'go.mod', '.git')(fname) or util.path.dirname(fname)
+          end,
+          single_file_support = true,
+        },
         nim_langserver = {}, -- aliased to 'nimls' below
         zls = {
           root_dir = function(fname)

--- a/nvim/lua/custom/plugins/mason.lua
+++ b/nvim/lua/custom/plugins/mason.lua
@@ -135,6 +135,7 @@ return {
 
       local servers = {
         gopls = {
+          filetypes = { 'go', 'gomod', 'gowork', 'gotmpl' },
           root_dir = function(fname)
             return util.root_pattern('go.work', 'go.mod', '.git')(fname) or util.path.dirname(fname)
           end,

--- a/nvim/lua/custom/plugins/mason.lua
+++ b/nvim/lua/custom/plugins/mason.lua
@@ -134,13 +134,8 @@ return {
       local util = require 'lspconfig.util' -- safe submodule for root helpers
 
       local servers = {
-        gopls = {
-          filetypes = { 'go', 'gomod', 'gowork', 'gotmpl' },
-          root_dir = function(fname)
-            return util.root_pattern('go.work', 'go.mod', '.git')(fname) or util.path.dirname(fname)
-          end,
-          single_file_support = true,
-        },
+        gopls = {},
+
         nim_langserver = {}, -- aliased to 'nimls' below
         zls = {
           root_dir = function(fname)
@@ -194,20 +189,33 @@ return {
         automatic_enable = false,
       }
 
-      local has_lsp_enable = type(vim.lsp.config) == 'function' and type(vim.lsp.enable) == 'function'
-      local lspconfig = has_lsp_enable and nil or require 'lspconfig'
-
       for name, cfg in pairs(servers) do
         local server_name = normalize_server_name(name)
         local merged_config = vim.tbl_deep_extend('force', {
           capabilities = vim.tbl_deep_extend('force', {}, capabilities),
         }, cfg or {})
 
-        if has_lsp_enable then
-          vim.lsp.config(server_name, merged_config)
-          vim.lsp.enable(server_name)
-        else
-          lspconfig[server_name].setup(merged_config)
+        vim.lsp.config(server_name, merged_config)
+        vim.lsp.enable(server_name)
+      end
+
+      ---------------------------------------------------------------------------
+      -- Custom non-Mason servers
+      ---------------------------------------------------------------------------
+      do
+        local ok, ahk = pcall(require, 'custom.ahk2')
+        if ok then
+          local ahk_config, err = ahk.build_config()
+          if ahk_config then
+            ahk_config.capabilities = vim.tbl_deep_extend('force', {}, capabilities, ahk_config.capabilities or {})
+
+            vim.lsp.config('ahk2', ahk_config)
+            vim.lsp.enable 'ahk2'
+          else
+            vim.schedule(function()
+              vim.notify(err, vim.log.levels.WARN)
+            end)
+          end
         end
       end
     end,

--- a/nvim/lua/custom/plugins/nvim-cmp.lua
+++ b/nvim/lua/custom/plugins/nvim-cmp.lua
@@ -139,6 +139,21 @@ return {
       })
 
       local cmdline_mapping = cmp.mapping.preset.cmdline()
+      -- Keep command-line Tab navigation consistent with Noice popupmenu UX.
+      cmdline_mapping['<Tab>'] = cmp.mapping(function(fallback)
+        if cmp.visible() then
+          cmp.select_next_item()
+        else
+          cmp.complete()
+        end
+      end, { 'c' })
+      cmdline_mapping['<S-Tab>'] = cmp.mapping(function(fallback)
+        if cmp.visible() then
+          cmp.select_prev_item()
+        else
+          fallback()
+        end
+      end, { 'c' })
       cmdline_mapping['<CR>'] = cmp.mapping(function(fallback)
         fallback()
       end, { 'c' })
@@ -151,6 +166,9 @@ return {
       end, { 'c' })
 
       cmp.setup.cmdline(':', {
+        completion = {
+          autocomplete = { cmp.TriggerEvent.TextChanged },
+        },
         enabled = function()
           if vim.fn.getcmdtype() ~= ':' then
             return true


### PR DESCRIPTION
### Motivation
- Align command-line completion navigation with Noice popupmenu UX so users can cycle candidates with Tab/Shift-Tab in `:` commands.
- Surface completion suggestions proactively while typing command arguments (e.g. `:go `) so the Noice popup shows candidates without manual triggering.
- Preserve existing command execution and special-case behavior so normal `:<CR>` execution and `:term` handling remain unchanged.

### Description
- Added command-line mappings in `nvim/lua/custom/plugins/nvim-cmp.lua` so `<Tab>` selects the next item or triggers completion when the menu is closed by calling `cmp.select_next_item()` / `cmp.complete()`. 
- Added `<S-Tab>` mapping that selects the previous item when visible and falls back otherwise by calling `cmp.select_prev_item()` or `fallback()`.
- Kept the existing `<CR>` fallback behavior and the `<C-y>` confirm-only-when-selected behavior intact by preserving `cmdline_mapping['<CR>']` and `cmdline_mapping['<C-y>']`.
- Enabled proactive command-line completion for `:` by adding `completion = { autocomplete = { cmp.TriggerEvent.TextChanged } }` to the `cmp.setup.cmdline(':', ...)` block, while leaving the `:term` special-case guard logic untouched.
- Added a short inline comment noting that Tab/Shift-Tab command-line navigation is intentionally aligned with Noice popupmenu UX, and left Noice settings in `nvim/lua/custom/plugins/noice.lua` unchanged (`cmdline.view = 'cmdline_popup'`, `popupmenu.enabled = true`, `popupmenu.backend = 'cmp'`).

### Testing
- Ran `git diff --check` to validate whitespace/errors and it returned no issues.
- Verified repository status with `git status --short` to confirm the intended file modification was staged, which succeeded.
- Committed the change to `nvim/lua/custom/plugins/nvim-cmp.lua` and confirmed the commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8b809ff08332920f65c14d274129)