### PR TITLE
Add dedicated Typst preview plugin spec

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -102,6 +102,12 @@ after every save so you retain the folded overview. If you relied on creating ma
 folds, use `zf` to define them per buffer or switch the method back temporarily with
 `:setlocal foldmethod=manual`.
 
+### Typst tooling
+
+* Start preview with `:TypstPreview` (or `<leader>tp` once a Typst buffer is open).
+* Required external binaries: `typst` CLI and `curl` (the plugin uses `curl` to fetch/update `tinymist` + `websocat` through `:TypstPreviewUpdate`).
+* Troubleshooting missing executables: run `:checkhealth`, then `:echo executable('typst')` / `:echo executable('curl')`; if either returns `0`, install it and restart Neovim.
+
 ### Rust tools
 
 | Shortcut | Action |

--- a/nvim/lua/custom/plugins/typst.lua
+++ b/nvim/lua/custom/plugins/typst.lua
@@ -1,0 +1,46 @@
+return {
+  {
+    'chomosuke/typst-preview.nvim',
+    ft = { 'typst' },
+    version = '1.*',
+    keys = {
+      { '<leader>tp', '<cmd>TypstPreview<cr>', desc = 'Typst: Start preview' },
+      { '<leader>tP', '<cmd>TypstPreviewToggle<cr>', desc = 'Typst: Toggle preview' },
+      { '<leader>ts', '<cmd>TypstPreviewStop<cr>', desc = 'Typst: Stop preview' },
+    },
+    config = function()
+      local function warn_missing(bin, reason)
+        vim.notify(
+          ('typst-preview: `%s` not found%s'):format(bin, reason and (' (' .. reason .. ')') or ''),
+          vim.log.levels.WARN
+        )
+      end
+
+      if vim.fn.executable('curl') ~= 1 then
+        warn_missing('curl', 'required to download/update preview binaries')
+      end
+
+      if vim.fn.executable('typst') ~= 1 then
+        warn_missing('typst', 'install Typst CLI for document compilation')
+      end
+
+      local has_tinymist = vim.fn.executable('tinymist') == 1 or vim.fn.executable('tinymist.cmd') == 1
+      local has_websocat = vim.fn.executable('websocat') == 1 or vim.fn.executable('websocat.exe') == 1
+      if not has_tinymist or not has_websocat then
+        vim.notify(
+          'typst-preview: tinymist/websocat not found in PATH; plugin can auto-download them via :TypstPreviewUpdate',
+          vim.log.levels.WARN
+        )
+      end
+
+      require('typst-preview').setup {
+        follow_cursor = false,
+        invert_colors = 'always',
+        dependencies_bin = {
+          tinymist = nil,
+          websocat = nil,
+        },
+      }
+    end,
+  },
+}


### PR DESCRIPTION
### Motivation

- Bring Typst preview integration into the repo's `custom.plugins` module pattern so it lazy-loads per filetype and is discoverable with other language plugins.
- Keep startup lightweight and cross-platform by using conservative defaults and avoiding hardcoded OS-specific binary paths.
- Provide a better DX by warning (not failing) when required external tooling is missing and exposing common commands/keymaps.

### Description

- Added a new plugin spec at `nvim/lua/custom/plugins/typst.lua` registering `chomosuke/typst-preview.nvim` with `ft = { 'typst' }` for filetype-lazy loading.
- Added keymaps for `:TypstPreview`, `:TypstPreviewToggle`, and `:TypstPreviewStop` so preview actions are discoverable via `:help`/which-key-like UIs.
- Implemented defensive checks using `vim.fn.executable()` and `vim.notify(..., vim.log.levels.WARN)` for `curl`, `typst`, and preview backends (`tinymist`/`websocat`) instead of hard errors.
- Configures `require('typst-preview').setup{}` with conservative defaults (`follow_cursor = false`, `invert_colors = 'always'`, and `dependencies_bin` left nil to avoid pinned OS paths) and no auto-start behavior.
- Added a short usage and troubleshooting note to `nvim/README.md` under tooling describing the start command, required binaries, and a quick check for missing executables.

### Testing

- Attempted a Lua syntax/load validation with `luac -p nvim/lua/custom/plugins/typst.lua`, which could not run because `luac` is not installed in the environment (failure due to missing tool).
- Attempted to `loadfile` the plugin spec via `lua -e "assert(loadfile('nvim/lua/custom/plugins/typst.lua'))"`, which could not run because `lua` is not available in the environment (failure due to missing tool).
- No runtime/plugin integration tests were executed in this environment; validation performed was static inspection of the added files and diffs which confirm the intended lazy loading, keymaps, setup defaults, and README entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d18d707b20833292ac1c0acaaa2fa7)