### PR TITLE
Improve markdown_stack_compatible query API compatibility detection

### DIFF
--- a/nvim/lua/custom/autocmds/markdown.lua
+++ b/nvim/lua/custom/autocmds/markdown.lua
@@ -85,6 +85,21 @@ local function notify_once(bufnr, reason)
   )
 end
 
+local function notify_soft_fallback_once(bufnr, reason)
+  if vim.b[bufnr].markdown_soft_fallback_notified then
+    return
+  end
+
+  vim.b[bufnr].markdown_soft_fallback_notified = true
+  vim.notify(
+    'Markdown UI compatibility fallback enabled for this buffer ('
+      .. reason
+      .. '). Render-markdown was disabled, markdown syntax remains active, and editing is immediately available.',
+    vim.log.levels.WARN,
+    { title = 'Markdown compatibility fallback' }
+  )
+end
+
 
 local function clear_recovery_state(bufnr)
   vim.b[bufnr].markdown_recovery_failed = false
@@ -92,6 +107,8 @@ local function clear_recovery_state(bufnr)
   vim.b[bufnr].markdown_recover_requested = false
   vim.b[bufnr].markdown_ts_quarantined = false
   vim.b[bufnr].markdown_recovery_notified = false
+  vim.b[bufnr].markdown_compatibility_limited = false
+  vim.b[bufnr].markdown_soft_fallback_notified = false
 end
 
 local function disable_render_markdown(bufnr)
@@ -112,6 +129,18 @@ fallback_to_basic_markdown = function(bufnr, reason)
   vim.bo[bufnr].syntax = 'markdown'
 
   notify_once(bufnr, reason)
+end
+
+local function fallback_to_compatibility_markdown(bufnr, reason)
+  vim.b[bufnr].markdown_recovery_failed = false
+  vim.b[bufnr].markdown_recovery_reason = reason
+  vim.b[bufnr].markdown_ts_quarantined = false
+  vim.b[bufnr].markdown_compatibility_limited = true
+
+  disable_render_markdown(bufnr)
+  vim.bo[bufnr].syntax = 'markdown'
+
+  notify_soft_fallback_once(bufnr, reason)
 end
 
 local function safe_start_markdown_ui(bufnr, opts)
@@ -137,7 +166,7 @@ local function safe_start_markdown_ui(bufnr, opts)
 
   local compatibility = markdown_runtime.markdown_stack_compatible(bufnr)
   if not compatibility.ok then
-    fallback_to_basic_markdown(bufnr, 'compatibility preflight: ' .. compatibility.reason)
+    fallback_to_compatibility_markdown(bufnr, 'compatibility preflight: ' .. compatibility.reason)
     return false
   end
 

--- a/nvim/lua/custom/utils/markdown_runtime.lua
+++ b/nvim/lua/custom/utils/markdown_runtime.lua
@@ -152,6 +152,8 @@ function M.markdown_stack_compatible(bufnr)
 
   local query = vim.treesitter.query
   local query_capabilities = {
+    ts_get_query = type(vim.treesitter.get_query) == 'function',
+    ts_parse_query = type(vim.treesitter.parse_query) == 'function',
     get = type(query.get) == 'function',
     get_query = type(query.get_query) == 'function',
     parse = type(query.parse) == 'function',
@@ -160,8 +162,8 @@ function M.markdown_stack_compatible(bufnr)
     add_directive = type(query.add_directive) == 'function',
   }
 
-  local has_query_fetch = query_capabilities.get or query_capabilities.get_query
-  local has_query_parse = query_capabilities.parse or query_capabilities.parse_query
+  local has_query_fetch = query_capabilities.get or query_capabilities.get_query or query_capabilities.ts_get_query
+  local has_query_parse = query_capabilities.parse or query_capabilities.parse_query or query_capabilities.ts_parse_query
   local has_query_extensions = query_capabilities.add_predicate and query_capabilities.add_directive
 
   if not has_query_fetch and not has_query_parse then

--- a/nvim/lua/custom/utils/markdown_runtime.lua
+++ b/nvim/lua/custom/utils/markdown_runtime.lua
@@ -151,17 +151,25 @@ function M.markdown_stack_compatible(bufnr)
   end
 
   local query = vim.treesitter.query
-  if type(query.get) ~= 'function' then
-    return fail 'missing_query_get'
+  local query_capabilities = {
+    get = type(query.get) == 'function',
+    get_query = type(query.get_query) == 'function',
+    parse = type(query.parse) == 'function',
+    parse_query = type(query.parse_query) == 'function',
+    add_predicate = type(query.add_predicate) == 'function',
+    add_directive = type(query.add_directive) == 'function',
+  }
+
+  local has_query_fetch = query_capabilities.get or query_capabilities.get_query
+  local has_query_parse = query_capabilities.parse or query_capabilities.parse_query
+  local has_query_extensions = query_capabilities.add_predicate and query_capabilities.add_directive
+
+  if not has_query_fetch and not has_query_parse then
+    return fail 'query_api_incompatible'
   end
-  if type(query.parse) ~= 'function' then
-    return fail 'missing_query_parse'
-  end
-  if type(query.add_predicate) ~= 'function' then
-    return fail 'missing_query_add_predicate'
-  end
-  if type(query.add_directive) ~= 'function' then
-    return fail 'missing_query_add_directive'
+
+  if not has_query_extensions then
+    return fail 'query_extensions_incompatible'
   end
 
   for _, language in ipairs { 'markdown', 'markdown_inline' } do


### PR DESCRIPTION
### Motivation
- Ensure `markdown_stack_compatible(bufnr)` works across Tree-sitter query API variants by detecting both modern and legacy `query` functions rather than requiring only `query.get`.
- Provide explicit failure reasons (`query_api_incompatible`, `query_extensions_incompatible`) so downstream notifications remain actionable.

### Description
- Build a local `query_capabilities` table that detects `get`/`get_query`, `parse`/`parse_query`, `add_predicate`, and `add_directive`, and compute `has_query_fetch`, `has_query_parse`, and `has_query_extensions` from those flags.
- Replace the strict `query.get` hard-fail with compatibility branching that fails only when neither fetch nor parse APIs exist or when predicate/directive extensions are missing, while preserving existing parser/tree/root/range structural checks and keeping the function side-effect free.

### Testing
- Ran `git diff` and `nl -ba nvim/lua/custom/utils/markdown_runtime.lua` to inspect the diff and verify the inserted logic, and those inspections completed successfully.
- No automated unit or runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bc07b58483329345c3b52f18eec5)