### PR TITLE
Pin nvim-treesitter to master for legacy configs.setup compatibility

### DIFF
--- a/nvim/lua/custom/plugins/nvim-treesitter.lua
+++ b/nvim/lua/custom/plugins/nvim-treesitter.lua
@@ -1,6 +1,9 @@
 return {
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
+    -- Keep `master` while this config intentionally uses `nvim-treesitter.configs`.
+    -- The `main` branch expects the newer `require('nvim-treesitter').setup()` API shape.
+    branch = 'master',
     build = ':TSUpdate',
     -- Compatibility policy: Markdown rendering integrations require matching
     -- Neovim + Treesitter query APIs (notably parser/query predicate helpers).
@@ -76,6 +79,8 @@ return {
         opts.indent.disable = indent_disable
       end
 
+      -- Compatibility pairing is intentional: `master` branch + `configs.setup` API.
+      -- Change branch and setup API together to avoid markdown/query preflight breakage.
       require('nvim-treesitter.configs').setup(opts)
     end,
     -- There are additional nvim-treesitter modules that you can use to interact


### PR DESCRIPTION
### Motivation
- The existing Treesitter config uses the legacy API `require('nvim-treesitter.configs').setup(...)`, so the plugin must be pinned to a branch that provides that API shape; no skills from the available AGENTS.md skill list were required or used for this change.

### Description
- Add `branch = 'master'` and an in-file comment to `nvim/lua/custom/plugins/nvim-treesitter.lua` to document and enforce the compatibility pairing (`master` + `configs.setup`) while keeping Markdown parsers (`markdown`, `markdown_inline`) managed via `ensure_installed` and avoiding mixed API usage.

### Testing
- Ran `rg` to confirm the setup API shape and `git diff` to review the change, and committed the file with `git commit`, all of which succeeded; no lockfile (e.g., `lazy-lock.json`) exists in the repo so no lockfile update was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c2d775848332bd7ab9b738fd1809)