### PR TITLE
Add MarkdownHealth treesitter compatibility diagnostics

### DIFF
--- a/nvim/lua/custom/autocmds/markdown.lua
+++ b/nvim/lua/custom/autocmds/markdown.lua
@@ -1,5 +1,7 @@
 local markdown_runtime = require 'custom.utils.markdown_runtime'
 
+local markdown_health = require 'custom.utils.markdown_health'
+
 local M = {}
 
 local markdown_error_interceptor_installed = false
@@ -196,6 +198,14 @@ function M.setup()
         safe_start_markdown_ui(event.buf)
       end)
     end,
+  })
+
+  -- Healthy output should show query_get/query_parse callable=true and markdown parsers available=true.
+  pcall(vim.api.nvim_del_user_command, 'MarkdownHealth')
+  vim.api.nvim_create_user_command('MarkdownHealth', function()
+    markdown_health.print_report()
+  end, {
+    desc = 'Print markdown treesitter compatibility and parser diagnostics',
   })
 
   pcall(vim.api.nvim_del_user_command, 'MarkdownRecover')

--- a/nvim/lua/custom/utils/markdown_health.lua
+++ b/nvim/lua/custom/utils/markdown_health.lua
@@ -1,0 +1,89 @@
+local M = {}
+
+local function safe_call(fn, ...)
+  if type(fn) ~= 'function' then
+    return false, 'not_callable'
+  end
+
+  local ok, result = pcall(fn, ...)
+  if not ok then
+    return false, tostring(result)
+  end
+
+  return true, result
+end
+
+local function parser_available(language)
+  if type(vim.treesitter) ~= 'table' or type(vim.treesitter.get_parser) ~= 'function' then
+    return {
+      language = language,
+      available = false,
+      reason = 'get_parser_unavailable',
+    }
+  end
+
+  local ok, parser_or_err = pcall(vim.treesitter.get_parser, 0, language)
+  if not ok then
+    return {
+      language = language,
+      available = false,
+      reason = tostring(parser_or_err),
+    }
+  end
+
+  return {
+    language = language,
+    available = parser_or_err ~= nil,
+    parser_type = type(parser_or_err),
+  }
+end
+
+function M.collect()
+  local query_module = type(vim.treesitter) == 'table' and vim.treesitter.query or nil
+
+  local report = {
+    neovim_version = vim.version(),
+    treesitter = {
+      present = vim.treesitter ~= nil,
+      type = type(vim.treesitter),
+      has_query_module = query_module ~= nil,
+      query_type = type(query_module),
+      query_get = type(query_module) == 'table' and type(query_module.get) or 'absent',
+      query_parse = type(query_module) == 'table' and type(query_module.parse) or 'absent',
+      query_get_callable = type(query_module) == 'table' and type(query_module.get) == 'function' or false,
+      query_parse_callable = type(query_module) == 'table' and type(query_module.parse) == 'function' or false,
+      legacy_get_query = type(vim.treesitter) == 'table' and type(vim.treesitter.get_query) or 'absent',
+      legacy_parse_query = type(vim.treesitter) == 'table' and type(vim.treesitter.parse_query) or 'absent',
+      legacy_get_query_callable = type(vim.treesitter) == 'table' and type(vim.treesitter.get_query) == 'function' or false,
+      legacy_parse_query_callable = type(vim.treesitter) == 'table' and type(vim.treesitter.parse_query) == 'function' or false,
+    },
+    parsers = {
+      markdown = parser_available 'markdown',
+      markdown_inline = parser_available 'markdown_inline',
+    },
+  }
+
+  local get_ok, get_result = safe_call(type(query_module) == 'table' and query_module.get, 'markdown', 'highlights')
+  report.treesitter.query_get_call = {
+    ok = get_ok,
+    detail = type(get_result),
+    error = get_ok and nil or get_result,
+  }
+
+  local parse_ok, parse_result = safe_call(type(query_module) == 'table' and query_module.parse, 'markdown', '(atx_heading (inline) @x)')
+  report.treesitter.query_parse_call = {
+    ok = parse_ok,
+    detail = type(parse_result),
+    error = parse_ok and nil or parse_result,
+  }
+
+  return report
+end
+
+function M.print_report()
+  local report = M.collect()
+  vim.print(report)
+  return report
+end
+
+return M


### PR DESCRIPTION
### Motivation
- Provide a read-only diagnostic that helps distinguish a Treesitter API mismatch from missing parsers for markdown features. 
- Make it easy for users to dump structured compatibility data from any session for debugging markdown render/highlighter issues.

### Description
- Add a new utility `nvim/lua/custom/utils/markdown_health.lua` that collects `vim.version()` and detailed Treesitter/query information including presence/type of `vim.treesitter` and `vim.treesitter.query`, callable/type status for `query.get` and `query.parse`, legacy API status for `vim.treesitter.get_query`/`vim.treesitter.parse_query`, safe probe call results, and parser availability for `markdown` and `markdown_inline` via `parser_available`.
- Expose `M.collect()` and `M.print_report()` which returns the structured report and prints it with `vim.print` for easy copy/paste.
- Register a stable user command `:MarkdownHealth` inside `nvim/lua/custom/autocmds/markdown.lua` that calls `markdown_health.print_report()` during markdown autocmd setup, and add a short comment indicating expected healthy fields.
- All diagnostics are read-only and implemented with `pcall`/type-checks to avoid side effects.

### Testing
- Attempted to run `nvim --headless '+lua require("custom.utils.markdown_health").collect()' +qa`, but the execution failed in this environment because the `nvim` binary is not installed (`/bin/bash: line 1: nvim: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c596e00c83329aec4ad0688caac5)