### PR TITLE
docs(markdown): clarify treesitter compatibility and fallback behavior

### DIFF
--- a/nvim/lua/custom/autocmds/markdown.lua
+++ b/nvim/lua/custom/autocmds/markdown.lua
@@ -117,6 +117,12 @@ fallback_to_basic_markdown = function(bufnr, reason)
 end
 
 local function safe_start_markdown_ui(bufnr, opts)
+  -- Fallback behavior in this file is intentional, not accidental:
+  -- - Enabled path: Treesitter markdown highlighter + RenderMarkdown UI.
+  -- - Fallback path: stop treesitter for this buffer, disable RenderMarkdown,
+  --   force `syntax=markdown`, and quarantine until :MarkdownRecover.
+  -- This quarantines known runtime failure modes (query/directive/range() nil
+  -- crashes) while preserving editor stability for normal editing.
   opts = opts or {}
   local explicit_recover = opts.explicit_recover == true
   if not is_markdown_buf(bufnr) then
@@ -200,7 +206,11 @@ function M.setup()
     end,
   })
 
-  -- Healthy output should show query_get/query_parse callable=true and markdown parsers available=true.
+  -- Upgrade checklist:
+  -- 1) If nvim-treesitter branch/API changes, update markdown_runtime probe.
+  -- 2) Re-run :MarkdownHealth (expect query_get/query_parse callable=true and
+  --    markdown parsers available=true).
+  -- 3) Confirm fallback warning is not triggered in normal markdown buffers.
   pcall(vim.api.nvim_del_user_command, 'MarkdownHealth')
   vim.api.nvim_create_user_command('MarkdownHealth', function()
     markdown_health.print_report()

--- a/nvim/lua/custom/plugins/nvim-treesitter.lua
+++ b/nvim/lua/custom/plugins/nvim-treesitter.lua
@@ -2,9 +2,19 @@ return {
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
-    -- Compatibility policy: Markdown rendering integrations require matching
-    -- Neovim + Treesitter query APIs (notably parser/query predicate helpers).
-    -- Guard markdown-dependent modules when parser/query APIs are unavailable.
+    -- Markdown stack compatibility + upgrade notes:
+    -- - API shape expected by this repo:
+    --   * `vim.treesitter.start/get_parser`
+    --   * `vim.treesitter.query.get/parse/add_predicate/add_directive`
+    --   * parser.parse() -> tree root() -> node.range() must all be callable.
+    -- - Branch/versioning strategy:
+    --   * This config is maintained for the stable/default branch released by
+    --     `nvim-treesitter/nvim-treesitter` plus `:TSUpdate`.
+    --   * If pinning to a commit or switching branch, treat that as an API change
+    --     and re-validate markdown runtime probes + :MarkdownHealth.
+    -- - Known-good baseline for debugging:
+    --   * Neovim v0.11.x + nvim-treesitter default/stable branch (HEAD updated
+    --     via `:TSUpdate`) with markdown + markdown_inline parsers installed.
     opts = {
       ensure_installed = {
         'bash',
@@ -57,6 +67,10 @@ return {
       vim.g.markdown_treesitter_ready = markdown_parser_ready
 
       if not markdown_parser_ready then
+        -- Intentional fallback: disable markdown treesitter highlight/indent when
+        -- markdown parser availability cannot be proven at setup time.
+        -- This keeps non-markdown treesitter features enabled and avoids markdown
+        -- highlighter startup paths that can later crash in callbacks.
         opts.highlight = opts.highlight or {}
         local highlight_disable = opts.highlight.disable or {}
         if type(highlight_disable) == 'string' then

--- a/nvim/lua/custom/utils/markdown_runtime.lua
+++ b/nvim/lua/custom/utils/markdown_runtime.lua
@@ -9,6 +9,24 @@ local DEFAULT_VAULT_PATHS = {
 local LARGE_MARKDOWN_LINE_THRESHOLD = 4000
 local LARGE_MARKDOWN_BYTE_THRESHOLD = 512 * 1024
 
+-- Treesitter compatibility contract for markdown integrations:
+-- - Expected API shape:
+--   * `vim.treesitter.start/get_parser`
+--   * `vim.treesitter.query.get/parse/add_predicate/add_directive`
+--   * parser.parse() -> tree.root() -> node.range() callable for markdown trees.
+-- - Why strict probing exists:
+--   * A branch/API mismatch can pass initial setup but fail later in
+--     decoration-provider callbacks (`range()` nil-style crashes).
+--   * Preflight checks let markdown autocmds intentionally fall back to Vim
+--     syntax + disabled render-markdown instead of crashing repeatedly.
+-- - Upgrade checklist:
+--   1) If changing nvim-treesitter branch/API or pin, update this probe.
+--   2) Re-run :MarkdownHealth and confirm query_get/query_parse/parser checks.
+--   3) Open a normal markdown buffer and confirm fallback warning is NOT shown.
+-- - Known-good baseline:
+--   * Neovim v0.11.x + nvim-treesitter default/stable branch (updated with
+--     :TSUpdate) with markdown + markdown_inline parsers present.
+
 local function normalize_path(path)
   if type(path) ~= 'string' or path == '' then
     return nil


### PR DESCRIPTION
### Motivation
- Prevent silent breakage when upgrading or pinning `nvim-treesitter` by documenting the exact Treesitter API shape this config relies on and why mismatches cause runtime crashes. 
- Make the markdown fallback behavior explicit so it is intentionally maintained rather than accidental during future changes. 
- Give contributors a short upgrade checklist and a known-good baseline to speed debugging and safe upgrades.

### Description
- Add API/upgrade notes to `nvim/lua/custom/plugins/nvim-treesitter.lua` documenting the expected Treesitter API shape (`vim.treesitter.start/get_parser`, `vim.treesitter.query.get/parse/add_predicate/add_directive`, and parser.parse -> tree.root -> node.range callability), the branch/versioning strategy (stable/default + `:TSUpdate`), and a known-good baseline (Neovim v0.11.x + default/stable Treesitter with markdown parsers).
- Add a Treesitter compatibility contract, rationale for strict preflight probing, an upgrade checklist, and the known-good baseline to `nvim/lua/custom/utils/markdown_runtime.lua` to centralize the runtime checks and guidance.
- Annotate `nvim/lua/custom/autocmds/markdown.lua` to state that the fallback path is intentional, what it disables/enables (stop treesitter for the buffer, disable `RenderMarkdown`, set `syntax=markdown`, and quarantine until `:MarkdownRecover`), and add an upgrade checklist advising to update probes and re-run `:MarkdownHealth`.

### Testing
- Performed local static verification by inspecting the repository diff and modified files to confirm the added comments appear in `plugins/nvim-treesitter.lua`, `utils/markdown_runtime.lua`, and `autocmds/markdown.lua` and that no runtime logic was removed or altered.
- Printed the updated files (`nl`/`sed` output) to validate the new explanatory comments and the upgrade checklist are present and readable.
- No automated unit tests were applicable; validation was limited to static repository/file inspections which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c685a9888332935d7fd60d0ccbe3)