### PR TITLE
Limit markdown preflight to top-level parser and add compatibility diagnostics

### DIFF
--- a/nvim/lua/custom/autocmds/markdown.lua
+++ b/nvim/lua/custom/autocmds/markdown.lua
@@ -83,6 +83,7 @@ local function normalize_reason_token(reason)
     missing_treesitter_runtime = true,
     missing_treesitter_start = true,
     missing_treesitter_get_parser = true,
+    missing_markdown_top_level_parser = true,
     treesitter_failure_signature = true,
     render_markdown_treesitter_directive_failure = true,
   }
@@ -111,6 +112,24 @@ local function normalize_reason_token(reason)
   end
 
   return token
+end
+
+local function debug_compatibility_reason(bufnr, stage, reason, details)
+  local message = string.format(
+    '[markdown-runtime] compatibility check failed (%s): %s%s',
+    stage or 'unknown_stage',
+    tostring(reason or 'unknown'),
+    details and details ~= '' and (' :: ' .. tostring(details)) or ''
+  )
+  vim.b[bufnr].markdown_compatibility_debug = {
+    stage = stage,
+    reason = reason,
+    details = details,
+    timestamp = os.date '!%Y-%m-%dT%H:%M:%SZ',
+  }
+  vim.schedule(function()
+    vim.notify(message, vim.log.levels.DEBUG, { title = 'Markdown compatibility debug' })
+  end)
 end
 
 local function notify_once(bufnr, reason)
@@ -184,7 +203,8 @@ local function safe_start_markdown_ui(bufnr, opts)
 
   local compatibility = markdown_runtime.markdown_stack_compatible(bufnr)
   if not compatibility.ok then
-    fallback_to_basic_markdown(bufnr, 'compatibility preflight: ' .. compatibility.reason)
+    debug_compatibility_reason(bufnr, 'preflight', compatibility.reason, compatibility.details)
+    fallback_to_basic_markdown(bufnr, 'compatibility_preflight_' .. tostring(compatibility.reason or 'unknown'))
     return false
   end
 
@@ -192,6 +212,7 @@ local function safe_start_markdown_ui(bufnr, opts)
   -- can happen later in the highlighter loop, so we also intercept runtime errors.
   local ok_ts, ts_err = pcall(vim.treesitter.start, bufnr)
   if not ok_ts and is_treesitter_failure(ts_err) then
+    debug_compatibility_reason(bufnr, 'treesitter_startup', 'treesitter_failure_signature', ts_err)
     fallback_to_basic_markdown(bufnr, 'treesitter failure signature')
     return false
   end
@@ -203,6 +224,7 @@ local function safe_start_markdown_ui(bufnr, opts)
   end)
 
   if not ok_render and is_treesitter_failure(render_err) then
+    debug_compatibility_reason(bufnr, 'render_markdown_enable', 'render_markdown_treesitter_directive_failure', render_err)
     fallback_to_basic_markdown(bufnr, 'render-markdown treesitter directive failure')
     return false
   end

--- a/nvim/lua/custom/utils/markdown_runtime.lua
+++ b/nvim/lua/custom/utils/markdown_runtime.lua
@@ -182,9 +182,12 @@ function M.markdown_stack_compatible(bufnr)
     return fail 'query_api_incompatible'
   end
 
-  for _, language in ipairs { 'markdown', 'markdown_inline' } do
+  for _, language in ipairs { 'markdown' } do
     local ok_parser, parser = pcall(vim.treesitter.get_parser, bufnr, language)
     if not ok_parser or parser == nil then
+      if language == 'markdown' then
+        return fail 'missing_markdown_top_level_parser'
+      end
       return fail('missing_parser_' .. language)
     end
 


### PR DESCRIPTION
### Motivation
- Prevent startup fallback from being triggered when only the optional `markdown_inline` parser cannot be started, while still blocking on true top-level parser failures.
- Make fallback reasons actionable and observable so operators can quickly identify whether failures come from parser startup, query API issues, or renderer-stage errors.
- Preserve existing safe-fallback behavior for hard failures but avoid blocking basic Markdown when only soft/optional capabilities are unavailable.

### Description
- In `nvim/lua/custom/utils/markdown_runtime.lua` restrict `markdown_stack_compatible` preflight to probe only the primary `markdown` parser instead of both `markdown` and `markdown_inline`, and return a specific failure token `missing_markdown_top_level_parser` when the top-level parser cannot be started. 
- In `nvim/lua/custom/autocmds/markdown.lua` add `missing_markdown_top_level_parser` to the known reason tokens so warnings normalize cleanly. 
- Add a `debug_compatibility_reason(bufnr, stage, reason, details)` helper that records `vim.b[bufnr].markdown_compatibility_debug` and emits a DEBUG notification describing the failing stage and details. 
- Use the debug hook to log preflight compatibility failures and to annotate failures during `treesitter.start` and `RenderMarkdown enable` attempts, and change fallback reason tokens to the explicit form `compatibility_preflight_<reason>` for 1:1 mapping to checks.

### Testing
- Attempted Lua syntax check with `luac -p nvim/lua/custom/utils/markdown_runtime.lua && luac -p nvim/lua/custom/autocmds/markdown.lua`, but `luac` is not installed in this environment so syntax validation could not run (failed). 
- Verified diffs and committed the changes to the branch, and inspected updated files with `git diff` and file previews (informational only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3cbcedfbc83328035cc33a92d89ff)