### PR TITLE
Move markdown autocmd after lazy setup, use Lua treesitter foldexpr, and disable playground plugin

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -89,7 +89,7 @@ vim.opt.tabstop = 4 -- Show a tab as 4 spaces
 vim.opt.softtabstop = 4 -- Insert 4 spaces when pressing Tab
 
 vim.opt.foldmethod = 'expr'
-vim.opt.foldexpr = 'nvim_treesitter#foldexpr()'
+vim.opt.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
 vim.opt.foldlevel = 99 -- Don't fold by default
 vim.opt.foldlevelstart = 99 -- Keep folds fully open in new windows
 vim.opt.foldcolumn = '1'
@@ -132,7 +132,6 @@ vim.keymap.set('n', '<C-k>', '<C-w><C-k>', {
 
 -- [[ Basic Autocommands ]]
 --  See `:help lua-guide-autocommands`
-require('custom.autocmds.markdown').setup()
 
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
@@ -205,7 +204,9 @@ require('lazy').setup({ {
       lazy = '💤 ',
     },
   },
-})
+)})
+
+require('custom.autocmds.markdown').setup()
 
 -- Move this inside config block to ensure it's called AFTER plugin is loaded
 -- COLOR SCHEME — manually comment/uncomment to select the one you want

--- a/nvim/lua/custom/plugins/nvim-playground.lua
+++ b/nvim/lua/custom/plugins/nvim-playground.lua
@@ -1,16 +1,6 @@
 return {
-
   {
     'nvim-treesitter/playground',
-    cmd = 'TSPlaygroundToggle',
-    config = function()
-      require('nvim-treesitter.configs').setup {
-        playground = {
-          enable = true,
-          updatetime = 25,
-          persist_queries = false,
-        },
-      }
-    end,
+    enabled = false,
   },
 }


### PR DESCRIPTION
### Motivation
- Ensure the Markdown autocommand runs after plugin registration so it can rely on plugin-provided behavior. 
- Replace legacy Vimscript treesitter fold expression with the current Lua API to avoid deprecated call sites. 
- Keep the `nvim-treesitter/playground` entry discoverable but disabled to stop active legacy configuration from loading.

### Description
- Moved `require('custom.autocmds.markdown').setup()` in `nvim/init.lua` so it executes after the `require('lazy').setup(...)` block at top-level. 
- Replaced `vim.opt.foldexpr = 'nvim_treesitter#foldexpr()'` with `vim.opt.foldexpr = 'v:lua.vim.treesitter.foldexpr()'` and left foldlevel/foldcolumn behavior unchanged. 
- Simplified `nvim/lua/custom/plugins/nvim-playground.lua` to return a lazy.nvim plugin table with the `nvim-treesitter/playground` entry set to `enabled = false`, removing the old `require('nvim-treesitter.configs').setup { playground = ... }` config path. 
- Verified the plugin file returns a valid table and that no active config path still sets up the playground.

### Testing
- Searched for legacy foldexpr occurrences with `rg "nvim_treesitter#foldexpr()" nvim/` and confirmed there are no remaining matches under `nvim/`. (succeeded)
- Inspected the updated `nvim/init.lua` and `nvim/lua/custom/plugins/nvim-playground.lua` with `sed`/`nl` to verify the autocmd ordering, the foldexpr replacement, and the disabled plugin entry. (succeeded)
- Committed the changes with `git commit` to record the update. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d21eab4c8332a176b3d1a55275e4)