### PR TITLE
Improve markdown treesitter query preflight diagnostics

### DIFF
--- a/nvim/lua/custom/autocmds/markdown.lua
+++ b/nvim/lua/custom/autocmds/markdown.lua
@@ -80,6 +80,8 @@ local function normalize_reason_token(reason)
     query_api_incompatible = true,
     query_get_missing = true,
     query_parse_missing = true,
+    query_get_failed = true,
+    query_parse_failed = true,
     missing_treesitter_runtime = true,
     missing_treesitter_start = true,
     missing_treesitter_get_parser = true,

--- a/nvim/lua/custom/utils/markdown_runtime.lua
+++ b/nvim/lua/custom/utils/markdown_runtime.lua
@@ -67,6 +67,27 @@ function M.is_obsidian_buffer(bufnr)
   return false
 end
 
+
+local function get_query_module()
+  if type(vim.treesitter) ~= 'table' then
+    return nil, 'missing_treesitter_runtime'
+  end
+
+  local query = vim.treesitter.query
+  if type(query) ~= 'table' or type(query.get) ~= 'function' or type(query.parse) ~= 'function' then
+    local ok_require, query_module = pcall(require, 'vim.treesitter.query')
+    if ok_require and type(query_module) == 'table' then
+      query = query_module
+    end
+  end
+
+  if type(query) ~= 'table' or type(query.get) ~= 'function' or type(query.parse) ~= 'function' then
+    return nil, 'query_namespace_missing'
+  end
+
+  return query, nil
+end
+
 local function has_markdown_injections(bufnr)
   local ok, parser = pcall(vim.treesitter.get_parser, bufnr, 'markdown')
   if not ok or not parser or type(parser.children) ~= 'function' then
@@ -146,40 +167,29 @@ function M.markdown_stack_compatible(bufnr)
     return fail 'missing_treesitter_get_parser'
   end
 
-  local ok_query, query = pcall(function()
-    return vim.treesitter.query
-  end)
-  if not ok_query then
-    return { ok = false, reason = 'query_namespace_missing', details = 'failed_to_read_treesitter_query_namespace' }
-  end
-
-  if type(query) ~= 'table' then
-    return fail 'query_namespace_missing'
+  local query, query_reason = get_query_module()
+  if not query then
+    return fail(query_reason or 'query_namespace_missing')
   end
 
   local get_fn = query.get
-  if type(get_fn) ~= 'function' then
-    get_fn = query.get_query
-  end
-
   if type(get_fn) ~= 'function' then
     return fail 'query_get_missing'
   end
 
   local parse_fn = query.parse
   if type(parse_fn) ~= 'function' then
-    parse_fn = query.parse_query
-  end
-
-  if type(parse_fn) ~= 'function' then
     return fail 'query_parse_missing'
   end
 
-  local ok_methods = pcall(function()
-    return get_fn, parse_fn
-  end)
-  if not ok_methods then
-    return fail 'query_api_incompatible'
+  local ok_get, get_err = pcall(get_fn, 'markdown', 'highlights')
+  if not ok_get then
+    return { ok = false, reason = 'query_get_failed', details = tostring(get_err) }
+  end
+
+  local ok_parse, parse_err = pcall(parse_fn, 'markdown', '((section) @markup.heading)')
+  if not ok_parse then
+    return { ok = false, reason = 'query_parse_failed', details = tostring(parse_err) }
   end
 
   for _, language in ipairs { 'markdown' } do


### PR DESCRIPTION
### Motivation

- Tighten and centralize detection of the Treesitter query runtime to provide clearer, non-crashing diagnostics when query APIs are missing or misbehaving. 
- Differentiate missing namespace vs. runtime execution failures so recovery logic can make better decisions and surface actionable messages.

### Description

- Add `get_query_module()` in `nvim/lua/custom/utils/markdown_runtime.lua` to centralize resolution of `vim.treesitter.query`, return `nil, 'missing_treesitter_runtime'` when `vim.treesitter` is absent, fall back to `pcall(require, 'vim.treesitter.query')`, and return `nil, 'query_namespace_missing'` when `get`/`parse` are not present.
- Replace legacy inline probing in `M.markdown_stack_compatible()` with `local query, query_reason = get_query_module()` and fail-fast with `fail(query_reason or 'query_namespace_missing')` when missing.
- Remove legacy fallbacks to `query.get_query` / `query.parse_query` and require `query.get` and `query.parse` to be functions.
- Add guarded runtime probes using `pcall(get_fn, 'markdown', 'highlights')` and `pcall(parse_fn, 'markdown', '((section) @markup.heading)')` that return `{ ok = false, reason = 'query_get_failed', details = ... }` or `{ ok = false, reason = 'query_parse_failed', details = ... }` on error.
- Update `normalize_reason_token()` in `nvim/lua/custom/autocmds/markdown.lua` to include `query_get_failed` and `query_parse_failed` in the known-token map so these tokens are preserved verbatim.
- Preserve existing return shapes and upstream expectations of `{ ok = false, reason = ..., details = ... }` and keep preflight behavior diagnostic-first and non-crashing.

### Testing

- Ran a project-wide search with `rg -n "get_query|parse_query|get_query_module|query_get_failed|query_parse_failed"` against the edited files to confirm removal of legacy references and presence of the new tokens, which returned the expected matches.
- Inspected the modified files (`nvim/lua/custom/utils/markdown_runtime.lua` and `nvim/lua/custom/autocmds/markdown.lua`) to verify the new helper and guarded probes are present and that return shapes were preserved; no automated test failures were produced by these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d2ac167c8332893617e72edc90b9)