### PR TITLE
Disable legacy markdown startup recovery hook and add regression tests

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -206,7 +206,8 @@ require('lazy').setup({ {
   },
 )})
 
-require('custom.autocmds.markdown').setup()
+-- Markdown rendering is now handled by `delphinus/md-render.nvim`
+-- Old crash-recovery layer is intentionally disabled
 
 -- Move this inside config block to ensure it's called AFTER plugin is loaded
 -- COLOR SCHEME — manually comment/uncomment to select the one you want

--- a/nvim/tests/unit/init_spec.lua
+++ b/nvim/tests/unit/init_spec.lua
@@ -1,0 +1,38 @@
+local function read(path)
+  local lines = vim.fn.readfile(path)
+  return table.concat(lines, '\n')
+end
+
+describe('startup config', function()
+  it('does not load custom.autocmds.markdown from startup paths', function()
+    local startup_files = {
+      'nvim/init.lua',
+      'nvim/lua/custom/plugins/init.lua',
+    }
+
+    for _, path in ipairs(startup_files) do
+      local content = read(path)
+      assert.is_nil(content:match("require%(['\"]custom%.autocmds%.markdown['\"]%)"), path .. ' should not require custom.autocmds.markdown')
+    end
+  end)
+
+  it('regression: startup config does not declare deprecated markdown commands', function()
+    local startup_files = {
+      'nvim/init.lua',
+      'nvim/lua/custom/plugins/init.lua',
+    }
+
+    local deprecated_commands = {
+      'MarkdownRecover',
+      'MarkdownHealth',
+      'RenderMarkdown',
+    }
+
+    for _, path in ipairs(startup_files) do
+      local content = read(path)
+      for _, cmd in ipairs(deprecated_commands) do
+        assert.is_nil(content:match(cmd), path .. ' should not include deprecated command ' .. cmd)
+      end
+    end
+  end)
+end)


### PR DESCRIPTION
### Motivation
- Prevent the legacy markdown crash-recovery layer from being invoked at startup because markdown rendering is now provided by `delphinus/md-render.nvim`.
- Add automated assertions to ensure the deprecated startup hook and its user-commands are not reintroduced by accident.

### Description
- Commented out the startup invocation by removing `require('custom.autocmds.markdown').setup()` and adding a short explanatory comment block in `nvim/init.lua`.
- Added `nvim/tests/unit/init_spec.lua` which asserts startup config sources do not `require` `custom.autocmds.markdown` and do not include deprecated commands `MarkdownRecover`, `MarkdownHealth`, or `RenderMarkdown`.
- Verified startup paths searched include `nvim/init.lua` and `nvim/lua/custom/plugins/init.lua` to ensure no alternate startup path loads the legacy module.

### Testing
- Ran repository searches with `rg` to confirm there are no remaining `require('custom.autocmds.markdown')` occurrences and no deprecated command names in startup paths, which succeeded.
- Created and staged the new unit test `nvim/tests/unit/init_spec.lua`, but executing the test runner `busted` was not possible because the environment is missing the Lua/Busted runtime.
- No additional automated test failures were observed from the file modifications themselves (tests were not executed due to the missing runtime).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51932eb40833297e2c22b4182b20c)