### PR TITLE
Add markdown runtime tests and preserve Obsidian event wiring

### DIFF
--- a/nvim/lua/custom/utils/markdown_runtime.lua
+++ b/nvim/lua/custom/utils/markdown_runtime.lua
@@ -43,6 +43,8 @@ local function workspace_paths()
 end
 
 function M.obsidian_events()
+  -- NOTE: This helper is intentionally still active and in-scope.
+  -- Obsidian plugin event wiring consumes this function directly.
   local events = {}
   for _, path in ipairs(workspace_paths()) do
     events[#events + 1] = 'BufReadPre ' .. path .. '/**/*.md'
@@ -141,6 +143,9 @@ function M.can_enable_render_markdown(bufnr)
     or vim.b[bufnr].obsidian_backlinks_active == true
     or vim.b[bufnr].obsidian_footer_active == true
 
+  -- Legacy compatibility guard for render-markdown coexistence.
+  -- Keep this behavior for now; planned cleanup will remove these helpers
+  -- once markdown runtime migration is complete.
   if M.is_obsidian_buffer(bufnr) and (obsidian_ui_active or package.loaded['obsidian'] ~= nil) then
     return false
   end

--- a/nvim/tests/unit/custom/markdown_runtime_spec.lua
+++ b/nvim/tests/unit/custom/markdown_runtime_spec.lua
@@ -1,0 +1,42 @@
+local markdown_runtime = require 'custom.utils.markdown_runtime'
+
+describe('custom.utils.markdown_runtime', function()
+  it('obsidian_events returns non-empty markdown event patterns', function()
+    vim.g.custom_obsidian_workspace_paths = {
+      '/tmp/notes',
+    }
+
+    local events = markdown_runtime.obsidian_events()
+
+    assert.is_true(type(events) == 'table')
+    assert.is_true(#events > 0)
+    assert.is_truthy(vim.tbl_contains(events, 'BufReadPre /tmp/notes/**/*.md'))
+    assert.is_truthy(vim.tbl_contains(events, 'BufNewFile /tmp/notes/**/*.md'))
+  end)
+
+  it('is_obsidian_buffer detects vault and non-vault paths', function()
+    vim.g.custom_obsidian_workspace_paths = {
+      '/vault/notes',
+    }
+
+    local original_get_name = vim.api.nvim_buf_get_name
+    vim.api.nvim_buf_get_name = function(bufnr)
+      if bufnr == 10 then
+        return '/vault/notes/daily/today.md'
+      end
+      if bufnr == 11 then
+        return '/other/place/today.md'
+      end
+      return ''
+    end
+
+    local ok, err = pcall(function()
+      assert.is_true(markdown_runtime.is_obsidian_buffer(10))
+      assert.is_false(markdown_runtime.is_obsidian_buffer(11))
+    end)
+
+    vim.api.nvim_buf_get_name = original_get_name
+
+    assert.is_true(ok, err)
+  end)
+end)

--- a/nvim/tests/unit/plugins/obsidian_spec.lua
+++ b/nvim/tests/unit/plugins/obsidian_spec.lua
@@ -1,0 +1,36 @@
+local function read(path)
+  local lines = vim.fn.readfile(path)
+  return table.concat(lines, '\n')
+end
+
+describe('obsidian plugin spec', function()
+  it('still consumes markdown_runtime.obsidian_events after markdown autocmd migration', function()
+    local startup_files = {
+      'nvim/init.lua',
+      'nvim/lua/custom/plugins/init.lua',
+    }
+
+    for _, path in ipairs(startup_files) do
+      local content = read(path)
+      assert.is_nil(content:match("require%(['\"]custom%.autocmds%.markdown['\"]%)"), path .. ' should not require custom.autocmds.markdown')
+    end
+
+    local original_runtime = package.loaded['custom.utils.markdown_runtime']
+    local calls = 0
+    local sentinel_events = { 'BufReadPre /mock/**/*.md' }
+
+    package.loaded['custom.utils.markdown_runtime'] = {
+      obsidian_events = function()
+        calls = calls + 1
+        return sentinel_events
+      end,
+    }
+
+    local ok, spec = pcall(dofile, 'nvim/lua/custom/plugins/obsidian.lua')
+    package.loaded['custom.utils.markdown_runtime'] = original_runtime
+
+    assert.is_true(ok, spec)
+    assert.are.same(sentinel_events, spec.event)
+    assert.are.equal(1, calls)
+  end)
+end)


### PR DESCRIPTION
### Motivation
- Prevent regressions during markdown/autocmd migration by preserving `obsidian_events()` usage and documenting legacy compatibility behavior in the markdown runtime.
- Provide automated coverage that `obsidian_events()` remains consumable by the Obsidian plugin and that buffer-vault detection logic remains correct.

### Description
- Add explanatory comments in `nvim/lua/custom/utils/markdown_runtime.lua` noting that `obsidian_events()` is intentionally still active and that render-markdown compatibility helpers are legacy and slated for cleanup.
- Keep `nvim/lua/custom/plugins/obsidian.lua` event wiring unchanged so the plugin continues to consume `markdown_runtime.obsidian_events()`.
- Add unit tests in `nvim/tests/unit/custom/markdown_runtime_spec.lua` to validate that `obsidian_events()` returns non-empty event patterns and that `is_obsidian_buffer()` correctly distinguishes vault vs non-vault paths.
- Add an integration-style plugin-spec test in `nvim/tests/unit/plugins/obsidian_spec.lua` that mocks `custom.utils.markdown_runtime` to confirm `obsidian.lua` consumes `markdown_runtime.obsidian_events()` and that startup paths do not require `custom.autocmds.markdown`.

### Testing
- Created test files `nvim/tests/unit/custom/markdown_runtime_spec.lua` and `nvim/tests/unit/plugins/obsidian_spec.lua` (tests were added to the repo but not executed against a test harness in this run).
- Performed a headless Neovim smoke command `nvim --headless -u NONE -c "lua print('ok')" -c qa` which completed successfully.
- Verified new test files are discoverable via file search (`rg`) and listed under `nvim/tests/unit`.
- Did not run a full `busted`/`plenary` test harness in this environment, so the new unit tests were not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51f22b0c08332a32953dc18f35f6b)