### PR TITLE
Add md-render migration regression tests, fixtures, and docs

### DIFF
--- a/nvim/tests/README.md
+++ b/nvim/tests/README.md
@@ -1,0 +1,17 @@
+# Neovim test notes
+
+## md-render migration regression contract
+
+`nvim/tests/unit/migrations/md_render_migration_spec.lua` is a pure Lua/spec-inspection regression test that protects the md-render migration contract without launching a full Neovim UI.
+
+The contract checks:
+
+- Positive assertions:
+  - `MdRender`, `MdRenderTab`, `MdRenderPager`, `MdRenderDemo` remain declared as plugin command triggers.
+  - `<leader>mp`, `<leader>mt`, `<leader>md` remain mapped to the expected `<Plug>` targets.
+- Negative assertions:
+  - No plugin or startup config references `RenderMarkdown`.
+  - No startup hook loads `custom.autocmds.markdown`.
+  - No plugin config calls `require('render-markdown')`.
+- Fixture alignment:
+  - `nvim/tests/fixtures/markdown/*.md|*.rmd|*.mdx` documents markdown-related filetypes and the test verifies plugin filetype scoping against them.

--- a/nvim/tests/fixtures/markdown/example.md
+++ b/nvim/tests/fixtures/markdown/example.md
@@ -1,0 +1,5 @@
+---
+filetype: markdown
+---
+
+# Markdown fixture

--- a/nvim/tests/fixtures/markdown/example.mdx
+++ b/nvim/tests/fixtures/markdown/example.mdx
@@ -1,0 +1,5 @@
+---
+filetype: markdown.mdx
+---
+
+# MDX fixture

--- a/nvim/tests/fixtures/markdown/example.rmd
+++ b/nvim/tests/fixtures/markdown/example.rmd
@@ -1,0 +1,5 @@
+---
+filetype: rmd
+---
+
+# R Markdown fixture

--- a/nvim/tests/unit/migrations/md_render_migration_spec.lua
+++ b/nvim/tests/unit/migrations/md_render_migration_spec.lua
@@ -1,0 +1,70 @@
+local function read(path)
+  local lines = vim.fn.readfile(path)
+  return table.concat(lines, '\n')
+end
+
+local function load_md_render_spec()
+  local spec = dofile('nvim/lua/custom/plugins/md-render.lua')
+  assert(type(spec) == 'table', 'plugin spec must be a table')
+  assert(type(spec[1]) == 'table', 'plugin spec must contain one plugin entry')
+  return spec[1]
+end
+
+describe('md-render migration regression contract', function()
+  it('declares MdRender commands as plugin command triggers', function()
+    local plugin = load_md_render_spec()
+
+    assert.are.same({ 'MdRender', 'MdRenderTab', 'MdRenderPager', 'MdRenderDemo' }, plugin.cmd)
+  end)
+
+  it('declares markdown-scoped mappings with expected <Plug> targets', function()
+    local plugin = load_md_render_spec()
+
+    assert.are.same({ '<leader>mp', '<Plug>(md-render-preview)', mode = 'n', ft = { 'markdown' } }, plugin.keys[1])
+    assert.are.same({ '<leader>mt', '<Plug>(md-render-preview-tab)', mode = 'n', ft = { 'markdown' } }, plugin.keys[2])
+    assert.are.same({ '<leader>md', '<Plug>(md-render-demo)', mode = 'n' }, plugin.keys[3])
+  end)
+
+  it('keeps markdown keymap scopes tied to markdown filetypes used by fixtures', function()
+    local plugin = load_md_render_spec()
+    local fixtures = {
+      ['nvim/tests/fixtures/markdown/example.md'] = 'markdown',
+      ['nvim/tests/fixtures/markdown/example.rmd'] = 'rmd',
+      ['nvim/tests/fixtures/markdown/example.mdx'] = 'markdown.mdx',
+    }
+
+    local declared_filetypes = {}
+    for _, ft in ipairs(plugin.ft or {}) do
+      declared_filetypes[ft] = true
+    end
+
+    for path, expected_ft in pairs(fixtures) do
+      local fixture = read(path)
+      assert.is_truthy(fixture:match('filetype:%s*' .. expected_ft), path .. ' should declare expected fixture filetype')
+      assert.is_true(declared_filetypes[expected_ft] == true, 'plugin.ft must include ' .. expected_ft)
+    end
+
+    for _, keymap in ipairs({ plugin.keys[1], plugin.keys[2] }) do
+      assert.is_true(vim.tbl_contains(keymap.ft or {}, 'markdown'))
+      assert.is_false(vim.tbl_contains(keymap.ft or {}, 'lua'))
+    end
+  end)
+
+  it('does not reference deprecated RenderMarkdown plugin/config/startup hooks', function()
+    local plugin = load_md_render_spec()
+    assert.is_nil(plugin[1]:match('RenderMarkdown'))
+
+    local files_to_scan = {
+      'nvim/init.lua',
+      'nvim/lua/custom/plugins/init.lua',
+      'nvim/lua/custom/plugins/md-render.lua',
+    }
+
+    for _, path in ipairs(files_to_scan) do
+      local content = read(path)
+      assert.is_nil(content:match('RenderMarkdown'), path .. ' should not reference RenderMarkdown')
+      assert.is_nil(content:match("require%(['\"]custom%.autocmds%.markdown['\"]%)"), path .. ' should not load markdown startup autocmd')
+      assert.is_nil(content:match("require%(['\"]render%-markdown['\"]%)"), path .. ' should not require render-markdown module')
+    end
+  end)
+end)


### PR DESCRIPTION
### Motivation
- Prevent regressions when swapping markdown renderers by enforcing a small, CI-friendly contract that can be validated via pure Lua/spec inspection without launching a full Neovim UI.
- Capture both positive expectations for the new `md-render` plugin surface and negative assertions that block accidental reintroduction of the old `RenderMarkdown` integration.

### Description
- Add a dedicated migration regression spec at `nvim/tests/unit/migrations/md_render_migration_spec.lua` that statically inspects the plugin spec and startup files for the required assertions.
- Implement positive assertions that `MdRender`, `MdRenderTab`, `MdRenderPager`, and `MdRenderDemo` are declared and that `<leader>mp`, `<leader>mt`, and `<leader>md` map to the expected `<Plug>` targets and are filetype-scoped.
- Implement negative assertions that no plugin or startup code references `RenderMarkdown`, that `custom.autocmds.markdown` is not loaded at startup, and that `require('render-markdown')` is not called.
- Add fixture markdown files under `nvim/tests/fixtures/markdown/` (`example.md`, `example.rmd`, `example.mdx`) and a short `nvim/tests/README.md` documenting the migration contract and fixture intent.

### Testing
- Attempted to run the new spec with `busted nvim/tests/unit/migrations/md_render_migration_spec.lua`, which failed in this environment because `busted` is not installed. (automated run: failed)
- Attempted to validate file loading with `lua -e "assert(loadfile(...))"`, which failed because `lua` is not available in this environment. (automated run: failed)
- The spec is written to be runnable by the repositoryâ€™s Lua/spec harness (pure spec/static inspection) so it should pass under CI when `busted`/Lua are available. (automated run: not executed due to missing test runtime)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51fe6734083328c60c5a5fce16246)