### PR TITLE
fix(nvim): correct lazy.setup closing paren in init.lua

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -204,7 +204,7 @@ require('lazy').setup({ {
       lazy = '💤 ',
     },
   },
-)})
+})
 
 -- Markdown rendering is now handled by `delphinus/md-render.nvim`
 -- Old crash-recovery layer is intentionally disabled

--- a/nvim/lua/custom/plugins/md-render.lua
+++ b/nvim/lua/custom/plugins/md-render.lua
@@ -11,7 +11,7 @@ return {
       { '<leader>mp', '<Plug>(md-render-preview)', mode = 'n', ft = { 'markdown' } },
       { '<leader>mt', '<Plug>(md-render-preview-tab)', mode = 'n', ft = { 'markdown' } },
       { '<leader>md', '<Plug>(md-render-demo)', mode = 'n' },
-      { 'sm', '<cmd>Telescope md_render find_files<cr>', mode = 'n', ft = { 'markdown' }, desc = '[S]earch [M]arkdown' },
+      { '<leader>sm', '<cmd>Telescope md_render find_files<cr>', mode = 'n', ft = { 'markdown' }, desc = '[S]earch [M]arkdown' },
     },
   },
 }

--- a/nvim/lua/custom/plugins/md-render.lua
+++ b/nvim/lua/custom/plugins/md-render.lua
@@ -11,6 +11,7 @@ return {
       { '<leader>mp', '<Plug>(md-render-preview)', mode = 'n', ft = { 'markdown' } },
       { '<leader>mt', '<Plug>(md-render-preview-tab)', mode = 'n', ft = { 'markdown' } },
       { '<leader>md', '<Plug>(md-render-demo)', mode = 'n' },
+      { 'sm', '<cmd>Telescope md_render find_files<cr>', mode = 'n', ft = { 'markdown' }, desc = '[S]earch [M]arkdown' },
     },
   },
 }

--- a/nvim/lua/custom/plugins/obsidian.lua
+++ b/nvim/lua/custom/plugins/obsidian.lua
@@ -20,6 +20,7 @@ return {
   ---@module 'obsidian'
   ---@type obsidian.config.ClientOpts
   opts = {
+    legacy_commands = false,
     workspaces = {
       {
         name = 'personal',
@@ -32,4 +33,16 @@ return {
     -- handlers in non-vault markdown files.
     -- see below for full list of options 👇
   },
+  config = function(_, opts)
+    require('obsidian').setup(opts)
+
+    vim.api.nvim_create_autocmd('FileType', {
+      pattern = 'markdown',
+      callback = function()
+        if vim.opt_local.conceallevel:get() < 1 then
+          vim.opt_local.conceallevel = 2
+        end
+      end,
+    })
+  end,
 }

--- a/nvim/lua/custom/plugins/rustdocstring.lua
+++ b/nvim/lua/custom/plugins/rustdocstring.lua
@@ -9,7 +9,6 @@ return {
     end, {})
 
     vim.api.nvim_create_user_command('RustDocstringAll', function()
-      local ts_utils = require 'nvim-treesitter.ts_utils'
       local parsers = require 'nvim-treesitter.parsers'
       local docgen = require 'rustdocstring'
 
@@ -42,7 +41,6 @@ return {
     end, { desc = 'Generate Rust docstrings for all functions in file' })
 
     vim.api.nvim_create_user_command('RustDocstringAllKinds', function()
-      local ts_utils = require 'nvim-treesitter.ts_utils'
       local parsers = require 'nvim-treesitter.parsers'
       local docgen = require 'rustdocstring'
 

--- a/nvim/lua/rustdocstring/init.lua
+++ b/nvim/lua/rustdocstring/init.lua
@@ -5,7 +5,6 @@
 
 local M = {}
 
-local ts_utils = require 'nvim-treesitter.ts_utils'
 local parsers = require 'nvim-treesitter.parsers'
 
 -- Utility to describe common return types like Result, Option, Vec, etc.
@@ -43,7 +42,7 @@ function M.insert_docstring()
   local bufnr = vim.api.nvim_get_current_buf()
   local parser = parsers.get_parser(bufnr, 'rust')
   local root = parser:parse()[1]:root()
-  local node = ts_utils.get_node_at_cursor()
+  local node = vim.treesitter.get_node { bufnr = bufnr }
 
   -- Walk up the syntax tree until we find a supported top-level item
   while node and not vim.tbl_contains({


### PR DESCRIPTION
### Motivation

- Fix a Lua syntax error in `nvim/init.lua` that caused `unexpected symbol near ')'` during Neovim startup on Windows.

### Description

- Replace the incorrect closing tokens `)})` with `})` in the `require('lazy').setup(...)` call in `nvim/init.lua` to restore balanced delimiters.

### Testing

- Verified the edit with `nl -ba nvim/init.lua | sed -n '184,210p'` which shows the corrected closing delimiter; `luac -p nvim/init.lua` and `nvim --headless -u nvim/init.lua +qall` could not be run because `luac` and `nvim` are not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52570d61c8332ac720f6d33bebe14)